### PR TITLE
Fill-in-the-blank exercises (frontend)

### DIFF
--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useState, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { api, Collection, Card, TestQuestion, TestAnswer, ProgressData, ProgressEntry } from "@/lib/api";
+import { api, Collection, Card, TestQuestion, TestAnswer, Exercise, ProgressData, ProgressEntry } from "@/lib/api";
 import LevelDot from "@/components/LevelDot";
 import SpeakButton from "@/components/SpeakButton";
 import { isLoggedIn } from "@/lib/auth";
 import Navbar from "@/components/Navbar";
 import ImageUpload from "@/components/ImageUpload";
+import ExerciseWorksheet from "@/components/ExerciseWorksheet";
 
 const inputCls = "border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 placeholder:text-gray-400 dark:placeholder:text-slate-500";
 const formCls = "bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-4 mb-3 flex flex-col gap-3";
@@ -244,6 +245,134 @@ function trunc(s: string, n: number) {
   return s.length > n ? s.slice(0, n) + "…" : s;
 }
 
+// ── Exercise import panel (YAML) ───────────────────────────────────────────────
+
+const exampleYAML = `- type: bank
+  title: "Verb to be"
+  sentences:
+    - text: "How ___ you?"
+      answer: [are]
+    - text: "My ___ ___ Vasiliy"
+      answer: [name, is]
+  distractors: [am, was]
+- type: choice
+  sentences:
+    - text: "I saw ___ elephant"
+      answer: [an]
+      distractors: [[a, the, some]]
+    - text: "She ___ to work ___ bus"
+      answer: [goes, by]
+      distractors:
+        - [go, going]
+        - [on]`;
+
+function ExerciseImportPanel({ collectionID, onImported, onCancel }: {
+  collectionID: string;
+  onImported: () => void; // reload the collection (panel stays open to show the result)
+  onCancel: () => void;
+}) {
+  const [text, setText] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null);
+
+  async function doImport() {
+    if (!text.trim()) return;
+    setImporting(true);
+    setError(null);
+    try {
+      const res = await api.exercises.importText(collectionID, text);
+      setResult(res);
+      setText("");
+      onImported();
+    } catch {
+      setError("Import failed — check the YAML/JSON format.");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div className={formCls}>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-medium text-gray-700 dark:text-slate-300">Import exercises (YAML or JSON)</p>
+        <a href="/exercises-format.md" download="cram-exercises-format.md" className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0">↓ AI format guide</a>
+      </div>
+      <textarea
+        className={inputCls + " min-h-[180px] resize-y font-mono text-xs"}
+        placeholder={exampleYAML}
+        value={text}
+        onChange={(e) => { setText(e.target.value); setResult(null); }}
+        autoFocus
+      />
+      {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
+      {result && (
+        <p className="text-xs font-medium text-green-600 dark:text-green-400">
+          ✓ Imported {result.imported} exercise{result.imported !== 1 ? "s" : ""}
+          {result.skipped > 0 && <span className="text-amber-600 dark:text-amber-400"> · {result.skipped} skipped (invalid)</span>}
+        </p>
+      )}
+      <div className="flex gap-2 justify-end">
+        <button type="button" onClick={onCancel} className="text-sm text-gray-500 dark:text-slate-400 px-3 py-1 hover:text-gray-700 dark:hover:text-slate-200">{result ? "Done" : "Cancel"}</button>
+        <button
+          onClick={doImport}
+          disabled={importing || !text.trim()}
+          className="bg-indigo-600 text-white px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {importing ? "Importing…" : "Import"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Manage panel: list exercises with a delete button each (append-only import, this is how
+// you remove items). Direct delete on the published collection — no draft flow.
+function ExerciseManagePanel({ collectionID, exercises, onChanged, onClose }: {
+  collectionID: string;
+  exercises: Exercise[];
+  onChanged: () => void;
+  onClose: () => void;
+}) {
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  async function del(exID: string) {
+    setDeleting(exID);
+    try {
+      await api.exercises.delete(collectionID, exID);
+      onChanged();
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div className={formCls}>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-gray-700 dark:text-slate-300">Edit exercises</p>
+        <button type="button" onClick={onClose} className="text-sm text-gray-500 dark:text-slate-400 px-2 hover:text-gray-700 dark:hover:text-slate-200">Done</button>
+      </div>
+      {exercises.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-slate-500">No exercises.</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {exercises.map((ex) => (
+            <li key={ex.ID} className="flex items-center gap-3 bg-gray-50 dark:bg-slate-800 rounded-lg px-3 py-2">
+              <span className="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-slate-700 text-gray-500 dark:text-slate-400 capitalize shrink-0">{ex.Kind}</span>
+              <span className="text-sm text-gray-700 dark:text-slate-300 truncate flex-1 min-w-0">
+                {ex.Title || `${ex.Sentences?.length ?? 0} sentence${(ex.Sentences?.length ?? 0) !== 1 ? "s" : ""}`}
+              </span>
+              <button type="button" onClick={() => del(ex.ID)} disabled={deleting === ex.ID} className="text-sm text-red-500 hover:text-red-600 dark:hover:text-red-300 shrink-0 disabled:opacity-50">
+                {deleting === ex.ID ? "…" : "Delete"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 
 // ── Card form ────────────────────────────────────────────────────────────────
 
@@ -404,11 +533,15 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [showImportTest, setShowImportTest] = useState(false);
+  const [showImportEx, setShowImportEx] = useState(false);
+  const [showManageEx, setShowManageEx] = useState(false);
   const [saving, setSaving] = useState(false);
   const [shareToken, setShareToken] = useState<string | null>(null);
   const [shareLoading, setShareLoading] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
   const [itemProgress, setItemProgress] = useState<Record<string, ProgressEntry>>({});
+  // sentenceID -> previously submitted words; null until loaded (gates worksheet render)
+  const [savedResults, setSavedResults] = useState<Record<string, string[]> | null>(null);
   const [isFollowed, setIsFollowed] = useState(false);
   const [followLoading, setFollowLoading] = useState(false);
 
@@ -433,6 +566,16 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
           for (const [id, entry] of Object.entries(data.test_questions)) merged[`tq:${id}`] = entry;
           setItemProgress(merged);
         }).catch(() => {});
+      }
+      // Restore saved exercise answers (only for exercises collections).
+      if (col.Type === "exercises" && loggedIn) {
+        api.exercises.getResults(col.ID).then((res) => {
+          const m: Record<string, string[]> = {};
+          for (const [sid, e] of Object.entries(res)) m[sid] = e.submitted;
+          setSavedResults(m);
+        }).catch(() => setSavedResults({}));
+      } else {
+        setSavedResults({});
       }
     }).catch(() => setError("Failed to load collection"));
   }, [router, props.params]);
@@ -711,8 +854,12 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
   // In view mode show active collection content; in edit mode show draft content.
   const cards = editMode ? editCards : (collection.Cards ?? []);
   const tests = editMode ? editTests : (collection.TestQuestions ?? []);
-  const isCards = collection.Type !== "tests";
+  const isExercises = collection.Type === "exercises";
+  const isCards = collection.Type === "cards";
   const isTests = collection.Type === "tests";
+  const exercises = collection.Exercises ?? [];
+  const typeLabel = isExercises ? "Exercises" : isTests ? "Tests" : "Cards";
+  const itemCount = isExercises ? exercises.length : isTests ? tests.length : cards.length;
   const hasFlip = isCards && cards.length >= 2;          // flip-card mode needs ≥2 cards
   const hasTest = isTests && tests.length >= 1;          // multiple-choice test (tests collections only)
   const hasBlitz = (isCards ? cards.length : tests.length) >= 1;
@@ -775,7 +922,7 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
         ) : (
           <div className="mb-4">
             <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">{collection.Title}</h1>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">{typeLabel} ({itemCount}): {collection.Title}</h1>
               <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${
                 collection.IsPublic
                   ? "bg-green-50 dark:bg-green-900/20 border-green-300 dark:border-green-700 text-green-700 dark:text-green-400"
@@ -788,8 +935,33 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
           </div>
         )}
 
+        {/* Exercises worksheet — entering the collection is the interactive sheet itself */}
+        {isExercises && !editMode && (
+          <div className="mb-8">
+            {exercises.length === 0 ? (
+              <div className="flex flex-col items-center gap-4 py-10 text-center">
+                <p className="text-sm text-gray-400 dark:text-slate-500">No exercises yet.</p>
+                {isOwner && (
+                  <>
+                    <p className="text-sm text-gray-500 dark:text-slate-400 max-w-sm">
+                      Generate exercises with an AI: download the format guide, paste it into ChatGPT/Claude with your topic, then <span className="font-medium">Import YAML</span> in settings below.
+                    </p>
+                    <a
+                      href="/exercises-format.md"
+                      download="cram-exercises-format.md"
+                      className="px-4 py-2 rounded-lg text-sm font-medium border border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/40 transition-colors"
+                    >
+                      ↓ Download AI format guide
+                    </a>
+                  </>
+                )}
+              </div>
+            ) : savedResults !== null && <ExerciseWorksheet exercises={exercises} collectionID={collection.ID} saved={savedResults} />}
+          </div>
+        )}
+
         {/* Study mode buttons + quick-add */}
-        {!editMode && (hasBlitz || isOwner || currentUserID !== null) && (
+        {!isExercises && !editMode && (hasBlitz || isOwner || currentUserID !== null) && (
           <div className="flex gap-3 mb-8 flex-wrap items-center">
             {hasBlitz && currentUserID !== null && (
               allMastered ? (
@@ -844,17 +1016,17 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
         {/* ── Cards section ── */}
         {isCards && (editMode || cards.length > 0) && (
           <div className="mb-8">
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="font-semibold text-gray-700 dark:text-slate-300">Cards ({cards.length})</h2>
-              {editMode && (
+            {editMode && (
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="font-semibold text-gray-700 dark:text-slate-300">Cards ({cards.length})</h2>
                 <div className="flex gap-2">
                   <button onClick={() => { closeAllForms(); setShowCardForm((v) => !v); }}
                     className={`${btnBase} border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/40`}>+ Add card</button>
                   <button onClick={() => { closeAllForms(); setShowImport((v) => !v); }}
                     className={`${btnBase} border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/40`}>+ Import</button>
                 </div>
-              )}
-            </div>
+              </div>
+            )}
 
             {editMode && showImport && draftCollectionID && (
               <ImportPanel
@@ -906,17 +1078,17 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
         {/* ── Test questions section ── */}
         {isTests && (editMode || tests.length > 0) && (
           <div className="mb-8">
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="font-semibold text-gray-700 dark:text-slate-300">Test questions ({tests.length})</h2>
-              {editMode && (
+            {editMode && (
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="font-semibold text-gray-700 dark:text-slate-300">Test questions ({tests.length})</h2>
                 <div className="flex gap-2">
                   <button onClick={() => { closeAllForms(); setShowTestForm((v) => !v); }}
                     className={`${btnBase} border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/40`}>+ Add question</button>
                   <button onClick={() => { closeAllForms(); setShowImportTest((v) => !v); }}
                     className={`${btnBase} border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/40`}>+ Import</button>
                 </div>
-              )}
-            </div>
+              </div>
+            )}
 
             {editMode && showImportTest && draftCollectionID && (
               <ImportTestPanel
@@ -973,7 +1145,8 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
         {!editMode && isOwner && (
           <div className="border-t border-gray-100 dark:border-slate-800 pt-6 mt-2 flex flex-col gap-3">
             <div className="flex flex-wrap gap-2">
-              {hasDraft ? (
+              {/* Exercises have no draft editor (yet) — they're edited via YAML import above. */}
+              {!isExercises && (hasDraft ? (
                 <>
                   <button onClick={enterEditMode} disabled={saving} className={`${btnBase} border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/40`}>
                     Continue editing
@@ -986,33 +1159,64 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
                 <button onClick={enterEditMode} disabled={saving} className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700`}>
                   {saving ? "Loading…" : "Edit"}
                 </button>
+              ))}
+              {isExercises && (
+                <button onClick={() => { setShowManageEx(false); setShowImportEx((v) => !v); }} className={`${btnBase} border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/40`}>
+                  + Import YAML
+                </button>
+              )}
+              {isExercises && exercises.length > 0 && (
+                <button onClick={() => { setShowImportEx(false); setShowManageEx((v) => !v); }} className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700`}>
+                  Edit
+                </button>
               )}
               <button onClick={togglePublic} className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700`}>
                 {collection.IsPublic ? "Make private" : "Make public"}
               </button>
-              <button onClick={generateShareLink} disabled={shareLoading || !!shareToken} className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-40`}>
-                {shareLoading ? "Generating…" : "Create share link"}
-              </button>
-              <button onClick={deleteCollection} className={`${btnBase} border-red-200 dark:border-red-800 bg-white dark:bg-slate-800 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20`}>
+              <button onClick={deleteCollection} className={`${btnBase} ml-auto border-red-200 dark:border-red-800 bg-white dark:bg-slate-800 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20`}>
                 Delete
               </button>
             </div>
 
-            {shareToken && (
-              <div className="flex items-center gap-2 flex-wrap">
-                <input
-                  readOnly
-                  value={`${typeof window !== "undefined" ? window.location.origin : ""}/shared/${shareToken}`}
-                  className={inputCls + " flex-1 min-w-0 font-mono text-xs"}
-                />
-                <button onClick={copyShareLink} className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 shrink-0`}>
-                  {shareCopied ? "Copied!" : "Copy"}
-                </button>
-                <button onClick={revokeShareLink} disabled={shareLoading} className={`${btnBase} border-red-200 dark:border-red-800 bg-white dark:bg-slate-800 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0`}>
-                  Revoke
-                </button>
-              </div>
+            {isExercises && showImportEx && (
+              <ExerciseImportPanel
+                collectionID={collection.ID}
+                onCancel={() => setShowImportEx(false)}
+                onImported={async () => { setCollection(await api.collections.get(collection.ID)); }}
+              />
             )}
+            {isExercises && showManageEx && (
+              <ExerciseManagePanel
+                collectionID={collection.ID}
+                exercises={exercises}
+                onChanged={async () => { setCollection(await api.collections.get(collection.ID)); }}
+                onClose={() => setShowManageEx(false)}
+              />
+            )}
+
+            {/* Share link — its own block: a Share button that becomes Revoke once a link exists.
+                Right-anchored so the button stays put when the link field appears. */}
+            <div className="flex items-center justify-end gap-2 flex-wrap border-t border-gray-100 dark:border-slate-800 pt-3">
+              {shareToken ? (
+                <>
+                  <input
+                    readOnly
+                    onClick={copyShareLink}
+                    title="Click to copy"
+                    value={`${typeof window !== "undefined" ? window.location.origin : ""}/shared/${shareToken}`}
+                    className={inputCls + " flex-1 min-w-0 font-mono text-xs cursor-pointer"}
+                  />
+                  {shareCopied && <span className="text-xs font-medium text-green-600 dark:text-green-400 shrink-0">Copied!</span>}
+                  <button onClick={revokeShareLink} disabled={shareLoading} className={`${btnBase} border-red-200 dark:border-red-800 bg-white dark:bg-slate-800 text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0 disabled:opacity-40`}>
+                    {shareLoading ? "…" : "Revoke"}
+                  </button>
+                </>
+              ) : (
+                <button onClick={generateShareLink} disabled={shareLoading} className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-40`}>
+                  {shareLoading ? "Generating…" : "Share"}
+                </button>
+              )}
+            </div>
           </div>
         )}
       </main>

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { api, Collection } from "@/lib/api";
+import { api, Collection, CollectionType } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
 import Navbar from "@/components/Navbar";
 
@@ -20,7 +20,7 @@ function CollectionItem({ c }: { c: Collection }) {
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400">
-            {c.Type === "tests" ? "Tests" : "Cards"}
+            {c.Type === "exercises" ? "Exercises" : c.Type === "tests" ? "Tests" : "Cards"}
           </span>
           <span className={`text-xs px-2 py-0.5 rounded-full ${c.IsPublic ? "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400" : "bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400"}`}>
             {c.IsPublic ? "Public" : "Private"}
@@ -40,7 +40,7 @@ export default function HomePage() {
   const [showForm, setShowForm] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [type, setType] = useState<"cards" | "tests">("cards");
+  const [type, setType] = useState<CollectionType>("cards");
 
   useEffect(() => {
     if (!isLoggedIn()) { router.replace("/"); return; }
@@ -54,7 +54,9 @@ export default function HomePage() {
     e.preventDefault();
     if (!title.trim()) return;
     const col = await api.collections.create(title.trim(), description.trim(), type);
-    router.push(`/collections/${col.ID}?edit=1`);
+    // Exercises are import-only (no draft editor); land on the collection where the
+    // owner can import YAML. Cards/tests open straight into the draft editor.
+    router.push(type === "exercises" ? `/collections/${col.ID}` : `/collections/${col.ID}?edit=1`);
   }
 
   const skeleton = (
@@ -86,6 +88,7 @@ export default function HomePage() {
                 {([
                   { v: "cards", label: "Flashcards" },
                   { v: "tests", label: "Test questions" },
+                  { v: "exercises", label: "Exercises" },
                 ] as const).map((opt) => (
                   <button
                     key={opt.v}

--- a/components/ExerciseWorksheet.tsx
+++ b/components/ExerciseWorksheet.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useRef, useState, type TouchEvent as ReactTouchEvent } from "react";
+import { Exercise, api } from "@/lib/api";
+import { segments, isCorrect, bankPool, gapOptions } from "@/lib/exercises";
+
+type SentenceResult = { id: string; correct: boolean; submitted: string[] };
+type Nav = { isFirst: boolean; isLast: boolean; onPrev: () => void; onNext: () => void };
+type BlockProps = {
+  ex: Exercise;
+  saved: Record<string, string[]>; // sentenceId -> submitted words; restores the answered state
+  onCheck: (results: SentenceResult[]) => void;
+  onReset: () => void;
+  nav: Nav;
+};
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+const card = "bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl p-6 shadow-sm";
+// matches the blitz/cards Confirm button (StudySession)
+const confirmBtn =
+  "border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors";
+const resetBtn =
+  "px-5 py-2 rounded-xl font-medium border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors";
+// solid indigo, like the blitz "Next →" (forward action after answering)
+const nextBtn =
+  "bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 transition-colors";
+const navBtn =
+  "text-sm font-medium px-3 py-1.5 rounded-lg text-gray-500 dark:text-slate-400 hover:text-gray-800 dark:hover:text-slate-200 transition-colors";
+
+// blitz-style coloured pill per exercise kind
+const kindBadge: Record<string, string> = {
+  bank: "bg-indigo-100 text-indigo-600 dark:bg-indigo-900/40 dark:text-indigo-400",
+  choice: "bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400",
+};
+
+// A blank slot — shared by bank and choice so both look identical.
+const slotBase = "inline-flex items-center justify-center align-middle mx-1 h-7 min-w-[3rem] px-2 rounded-md border text-sm";
+function slotColor(state: "empty" | "filled" | "correct" | "wrong"): string {
+  switch (state) {
+    case "correct": return "border-green-400 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300";
+    case "wrong": return "border-red-400 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300";
+    case "filled": return "border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300";
+    default: return "border-dashed border-gray-300 dark:border-slate-600 text-gray-300 dark:text-slate-600";
+  }
+}
+
+// Bottom bar lives OUTSIDE the card (under the border).
+//   Mobile (stepper, 3 slots): [← Prev] · [Skip/Reset] · [Confirm/Next →]  — slots keep
+//     their role (right = forward action, centre = secondary), so nothing jumps.
+//   Desktop (all blocks visible, no nav): a single centred action that swaps Confirm↔Reset
+//     in place — a lone button reads best centred (no left hint to balance it like blitz).
+function BlockActions({ checked, onConfirm, onReset, nav }: {
+  checked: boolean; onConfirm: () => void; onReset: () => void; nav: Nav;
+}) {
+  return (
+    <>
+      <div className="grid grid-cols-3 items-center mt-3 sm:hidden">
+        <div className="justify-self-start">
+          {!nav.isFirst && <button type="button" onClick={nav.onPrev} className={navBtn}>← Prev</button>}
+        </div>
+        <div className="justify-self-center">
+          {checked
+            ? <button type="button" onClick={onReset} className={resetBtn}>Reset</button>
+            : (!nav.isLast && <button type="button" onClick={nav.onNext} className={navBtn}>Skip</button>)}
+        </div>
+        <div className="justify-self-end">
+          {checked
+            ? (!nav.isLast && <button type="button" onClick={nav.onNext} className={nextBtn}>Next →</button>)
+            : <button type="button" onClick={onConfirm} className={confirmBtn}>Confirm</button>}
+        </div>
+      </div>
+      <div className="hidden sm:flex justify-center mt-3">
+        {checked
+          ? <button type="button" onClick={onReset} className={resetBtn}>Reset</button>
+          : <button type="button" onClick={onConfirm} className={confirmBtn}>Confirm</button>}
+      </div>
+    </>
+  );
+}
+
+// ── bank: shared shuffled word pool, drag-and-drop (or tap) into blanks ────────
+type PoolWord = { id: string; word: string };
+
+function BankBlock({ ex, saved, onCheck, onReset, nav }: BlockProps) {
+  const [poolWords] = useState<PoolWord[]>(() =>
+    shuffle(bankPool(ex).map((word, i) => ({ id: `p${i}`, word })))
+  );
+  const blankKeys = ex.Sentences.flatMap((s) => s.answer.map((_, i) => `${s.id}:${i}`));
+
+  const [placed, setPlaced] = useState<Record<string, string>>(() => {
+    const init: Record<string, string> = {};
+    const used = new Set<string>();
+    for (const s of ex.Sentences) {
+      const sub = saved[s.id];
+      if (!sub) continue;
+      sub.forEach((word, i) => {
+        const m = poolWords.find((p) => p.word === word && !used.has(p.id));
+        if (m) { init[`${s.id}:${i}`] = m.id; used.add(m.id); }
+      });
+    }
+    return init;
+  });
+  const [checked, setChecked] = useState(() => ex.Sentences.some((s) => saved[s.id]));
+  const dragRef = useRef<{ id: string; from?: string } | null>(null);
+
+  const wordById = (id: string) => poolWords.find((p) => p.id === id)?.word ?? "";
+  const usedIds = new Set(Object.values(placed));
+  const available = poolWords.filter((p) => !usedIds.has(p.id));
+  const answerOf = (key: string) => {
+    const [sid, idx] = key.split(":");
+    const s = ex.Sentences.find((x) => x.id === sid)!;
+    return s.answer[Number(idx)];
+  };
+
+  function placeAt(key: string, id: string, from?: string) {
+    if (checked) return;
+    setPlaced((prev) => {
+      const next = { ...prev };
+      for (const k of Object.keys(next)) if (next[k] === id) delete next[k];
+      if (from && from !== key) delete next[from];
+      next[key] = id;
+      return next;
+    });
+  }
+  function clearBlank(key: string) {
+    if (checked) return;
+    setPlaced((prev) => { const next = { ...prev }; delete next[key]; return next; });
+  }
+  function tapWord(id: string) {
+    const firstEmpty = blankKeys.find((k) => !placed[k]);
+    if (firstEmpty) placeAt(firstEmpty, id);
+  }
+
+  function slotClass(key: string) {
+    const id = placed[key];
+    if (!id) return slotColor("empty");
+    if (!checked) return slotColor("filled");
+    return wordById(id) === answerOf(key) ? slotColor("correct") : slotColor("wrong");
+  }
+
+  return (
+    <>
+      <section className={card}>
+        <div className="flex flex-col gap-4">
+          {!checked && (
+            <div
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => { const d = dragRef.current; if (d?.from) clearBlank(d.from); dragRef.current = null; }}
+              className="flex flex-wrap gap-2 min-h-[2.25rem] p-1 rounded-lg bg-gray-50 dark:bg-slate-800/50"
+            >
+              {available.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  draggable
+                  onDragStart={() => { dragRef.current = { id: p.id }; }}
+                  onClick={() => tapWord(p.id)}
+                  className="text-sm px-2.5 py-1 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-gray-800 dark:text-slate-200 hover:border-indigo-300 dark:hover:border-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 cursor-grab active:cursor-grabbing"
+                >
+                  {p.word}
+                </button>
+              ))}
+              {available.length === 0 && <span className="text-xs text-gray-400 dark:text-slate-500 px-1 self-center">all words placed</span>}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3">
+            {ex.Sentences.map((s) => {
+              const parts = segments(s.text);
+              return (
+                <div key={s.id} className="text-gray-900 dark:text-slate-100 leading-relaxed">
+                  {parts.map((part, i) => {
+                    const key = `${s.id}:${i}`;
+                    const id = placed[key];
+                    return (
+                      <span key={i}>
+                        {part}
+                        {i < parts.length - 1 && (
+                          <span
+                            onDragOver={(e) => e.preventDefault()}
+                            onDrop={() => { const d = dragRef.current; if (d) placeAt(key, d.id, d.from); dragRef.current = null; }}
+                            draggable={!checked && !!id}
+                            onDragStart={() => { if (id) dragRef.current = { id, from: key }; }}
+                            onClick={() => id && clearBlank(key)}
+                            className={`${slotBase} ${id && !checked ? "cursor-pointer" : ""} ${slotClass(key)}`}
+                          >
+                            {id ? wordById(id) : " "}
+                          </span>
+                        )}
+                      </span>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+      <BlockActions
+        checked={checked}
+        nav={nav}
+        onConfirm={() => {
+          setChecked(true);
+          onCheck(ex.Sentences.map((s) => {
+            const submitted = s.answer.map((_, i) => wordById(placed[`${s.id}:${i}`] ?? ""));
+            return { id: s.id, submitted, correct: isCorrect(s.answer, submitted) };
+          }));
+        }}
+        onReset={() => { onReset(); setChecked(false); setPlaced({}); }}
+      />
+    </>
+  );
+}
+
+// ── choice: an inline dropdown per gap ────────────────────────────────────────
+function ChoiceBlock({ ex, saved, onCheck, onReset, nav }: BlockProps) {
+  const [opts] = useState<Record<string, string[][]>>(() =>
+    Object.fromEntries(ex.Sentences.map((s) => [s.id, gapOptions(s).map((g) => shuffle(g))]))
+  );
+  const [sel, setSel] = useState<Record<string, string[]>>(() =>
+    Object.fromEntries(ex.Sentences.map((s) => [s.id, s.answer.map((_, i) => saved[s.id]?.[i] ?? "")]))
+  );
+  const [checked, setChecked] = useState(() => ex.Sentences.some((s) => saved[s.id]));
+
+  function setGap(sid: string, i: number, val: string) {
+    if (checked) return;
+    setSel((prev) => ({ ...prev, [sid]: prev[sid].map((v, j) => (j === i ? val : v)) }));
+  }
+  function gapState(sid: string, answer: string, i: number) {
+    const val = sel[sid][i];
+    return !checked ? (val ? "filled" : "empty") : val === answer ? "correct" : "wrong";
+  }
+
+  return (
+    <>
+      <section className={card}>
+        <div className="flex flex-col gap-3">
+          {ex.Sentences.map((s) => {
+            const parts = segments(s.text);
+            return (
+              <div key={s.id} className="text-gray-900 dark:text-slate-100 leading-relaxed">
+                {parts.map((part, i) => {
+                  if (i >= parts.length - 1) return <span key={i}>{part}</span>;
+                  const state = gapState(s.id, s.answer[i], i);
+                  return (
+                    <span key={i}>
+                      {part}
+                      <select
+                        value={sel[s.id][i]}
+                        onChange={(e) => setGap(s.id, i, e.target.value)}
+                        disabled={checked}
+                        className={`align-middle mx-1 h-7 min-w-[3.5rem] rounded-md border text-sm px-1 ${slotColor(state)}`}
+                      >
+                        <option value="">—</option>
+                        {opts[s.id][i].map((w) => <option key={w} value={w}>{w}</option>)}
+                      </select>
+                    </span>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+      <BlockActions
+        checked={checked}
+        nav={nav}
+        onConfirm={() => {
+          setChecked(true);
+          onCheck(ex.Sentences.map((s) => ({ id: s.id, submitted: sel[s.id], correct: isCorrect(s.answer, sel[s.id]) })));
+        }}
+        onReset={() => { onReset(); setChecked(false); setSel(Object.fromEntries(ex.Sentences.map((s) => [s.id, s.answer.map(() => "")]))); }}
+      />
+    </>
+  );
+}
+
+export default function ExerciseWorksheet({ exercises, collectionID, saved }: {
+  exercises: Exercise[];
+  collectionID: string;
+  saved: Record<string, string[]>;
+}) {
+  const [current, setCurrent] = useState(0);
+
+  function record(results: SentenceResult[]) {
+    api.exercises
+      .recordResults(collectionID, results.map((r) => ({ sentence_id: r.id, correct: r.correct, submitted: r.submitted })))
+      .catch(() => {});
+  }
+  function reset(exID: string) {
+    api.exercises.resetExercise(collectionID, exID).catch(() => {});
+  }
+
+  // Swipe between blocks on touch devices (mobile only — on desktop all blocks are shown).
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  function onTouchStart(e: ReactTouchEvent) {
+    const t = e.changedTouches[0];
+    touchStart.current = { x: t.clientX, y: t.clientY };
+  }
+  function onTouchEnd(e: ReactTouchEvent) {
+    const s = touchStart.current;
+    touchStart.current = null;
+    if (!s) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - s.x;
+    const dy = t.clientY - s.y;
+    if (Math.abs(dx) < 50 || Math.abs(dx) < Math.abs(dy)) return;
+    if (dx < 0) setCurrent((c) => Math.min(exercises.length - 1, c + 1));
+    else setCurrent((c) => Math.max(0, c - 1));
+  }
+
+  const nav = (i: number): Nav => ({
+    isFirst: i === 0,
+    isLast: i === exercises.length - 1,
+    onPrev: () => setCurrent((c) => Math.max(0, c - 1)),
+    onNext: () => setCurrent((c) => Math.min(exercises.length - 1, c + 1)),
+  });
+
+  return (
+    <div className="flex flex-col gap-8" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+      {exercises.map((ex, i) => (
+        <div key={ex.ID} className={`${i === current ? "block" : "hidden"} sm:block`}>
+          {/* header sits outside the card, like the counter/badge in blitz */}
+          <div className="flex items-center justify-between gap-2 mb-2 px-1">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-sm text-gray-400 dark:text-slate-500 shrink-0">{i + 1} / {exercises.length}</span>
+              {ex.Title && <h3 className="font-semibold text-gray-700 dark:text-slate-300 truncate">{ex.Title}</h3>}
+            </div>
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-full shrink-0 capitalize ${kindBadge[ex.Kind] ?? "bg-gray-100 text-gray-500 dark:bg-slate-800 dark:text-slate-400"}`}>
+              {ex.Kind}
+            </span>
+          </div>
+          {ex.Kind === "bank"
+            ? <BankBlock ex={ex} saved={saved} onCheck={record} onReset={() => reset(ex.ID)} nav={nav(i)} />
+            : <ChoiceBlock ex={ex} saved={saved} onCheck={record} onReset={() => reset(ex.ID)} nav={nav(i)} />}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { logout, isLoggedIn } from "@/lib/auth";
 import { useCurrentUser } from "@/contexts/UserContext";
 
+// isLoggedIn() reads localStorage, which is unavailable during SSR. useSyncExternalStore
+// returns the server snapshot (false) during hydration so the first client render matches
+// the server markup, then switches to the real client value — avoiding a hydration mismatch.
+function subscribeLoggedIn(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
 export default function Navbar() {
   const pathname = usePathname();
-  const loggedIn = isLoggedIn();
+  const loggedIn = useSyncExternalStore(subscribeLoggedIn, isLoggedIn, () => false);
   const currentUser = useCurrentUser();
   const isAdmin = currentUser?.role === "admin";
   const [menuOpen, setMenuOpen] = useState(false);

--- a/components/StudySession.tsx
+++ b/components/StudySession.tsx
@@ -258,6 +258,10 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   }
 
   const shownLevel = displayLevel ?? currentLevel;
+  // "See results" only on the genuine last step: the working queue grows when a wrong
+  // answer is requeued, so account for a requeue that this answer will trigger.
+  const willRequeue = requeueWrongCards && submitted && !item.isRetry && !isCorrect;
+  const isLastStep = index + 1 >= queue.length && !willRequeue;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -342,7 +346,7 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
               )}
               {submitted && (
                 <button onClick={next} className="bg-indigo-600 text-white px-6 py-2.5 rounded-xl font-medium hover:bg-indigo-700 transition-colors">
-                  {index + 1 >= items.length ? "See results" : "Next →"}
+                  {isLastStep ? "See results" : "Next →"}
                 </button>
               )}
             </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -21,12 +21,14 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   return res.json();
 }
 
+export type CollectionType = "cards" | "tests" | "exercises";
+
 export type Collection = {
   ID: string;
   UserID: string;
   Title: string;
   Description: string;
-  Type: "cards" | "tests";
+  Type: CollectionType;
   IsPublic: boolean;
   IsDraft: boolean;
   DraftOf: string | null;
@@ -34,6 +36,7 @@ export type Collection = {
   ShareToken: string | null;
   Cards: Card[] | null;
   TestQuestions: TestQuestion[] | null;
+  Exercises: Exercise[] | null;
   CreatedAt: string;
   UpdatedAt: string;
 };
@@ -83,6 +86,29 @@ export type TestQuestion = {
   Question: string;
   Options: TestAnswer[];
   Image: string;
+  Position: number;
+  CreatedAt: string;
+  UpdatedAt: string;
+};
+
+// One prompt within an exercise. `text` contains one or more "___" blanks; `answer`
+// holds the correct word for each blank in order. For "choice" exercises `distractors`
+// holds the wrong option words per blank (`distractors[i]` for blank `i`).
+export type ExerciseSentence = {
+  id: string;
+  text: string;
+  answer: string[];
+  distractors?: string[][]; // choice only: wrong options per blank (distractors[i] for blank i)
+  position: number;
+};
+
+export type Exercise = {
+  ID: string;
+  CollectionID: string;
+  Kind: "bank" | "choice";
+  Title: string;
+  Sentences: ExerciseSentence[];
+  Distractors: string[] | null; // bank only: extra words for the shared pool
   Position: number;
   CreatedAt: string;
   UpdatedAt: string;
@@ -156,7 +182,7 @@ export const api = {
     listPublic: () => request<PublicCollection[]>("/public/collections"),
     get: (id: string) => request<Collection>(`/collections/${id}`),
     getPublic: (id: string) => request<Collection>(`/public/collections/${id}`),
-    create: (title: string, description: string, type: "cards" | "tests" = "cards", isPublic = false) =>
+    create: (title: string, description: string, type: CollectionType = "cards", isPublic = false) =>
       request<Collection>("/collections", { method: "POST", body: JSON.stringify({ title, description, type, is_public: isPublic }) }),
     update: (id: string, title: string, description: string, isPublic: boolean) =>
       request<Collection>(`/collections/${id}`, { method: "PUT", body: JSON.stringify({ title, description, is_public: isPublic }) }),
@@ -195,6 +221,12 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ item_type: itemType, item_id: itemID, correct, confidence_delta: confidenceDelta, retry }),
       }),
+    reset: (collectionID: string) =>
+      request<void>(`/collections/${collectionID}/progress`, { method: "DELETE" }),
+    resetCard: (collectionID: string, cardID: string) =>
+      request<void>(`/collections/${collectionID}/cards/${cardID}/progress`, { method: "DELETE" }),
+    resetTest: (collectionID: string, tqID: string) =>
+      request<void>(`/collections/${collectionID}/tests/${tqID}/progress`, { method: "DELETE" }),
   },
   users: {
     list: () => request<UserProfile[]>("/users"),
@@ -247,6 +279,29 @@ export const api = {
       form.append("file", new Blob([text], { type: "text/csv" }), "import.csv");
       return request<{ imported: number }>(`/collections/${collectionID}/tests/import`, { method: "POST", body: form });
     },
+  },
+  exercises: {
+    // Import a YAML/JSON document (raw body) into an exercises collection.
+    importText: (collectionID: string, text: string) =>
+      request<{ imported: number; skipped: number }>(`/collections/${collectionID}/exercises/import`, {
+        method: "POST",
+        body: text,
+        headers: { "Content-Type": "application/x-yaml" },
+      }),
+    delete: (collectionID: string, exID: string) =>
+      request<void>(`/collections/${collectionID}/exercises/${exID}`, { method: "DELETE" }),
+    // Save each answered sentence's words + correctness (one-off worksheets, no leveling).
+    recordResults: (collectionID: string, results: { sentence_id: string; correct: boolean; submitted: string[] }[]) =>
+      request<void>(`/collections/${collectionID}/exercises/results`, {
+        method: "POST",
+        body: JSON.stringify({ results }),
+      }),
+    // The user's saved answers, keyed by sentence id — used to restore worksheet state.
+    getResults: (collectionID: string) =>
+      request<Record<string, { correct: boolean; submitted: string[] }>>(`/collections/${collectionID}/exercises/results`),
+    // Clear the user's own answers for one exercise (retake).
+    resetExercise: (collectionID: string, exID: string) =>
+      request<void>(`/collections/${collectionID}/exercises/${exID}/progress`, { method: "DELETE" }),
   },
   blitz: {
     get: (collectionID: string) =>

--- a/lib/exercises.test.ts
+++ b/lib/exercises.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { segments, blankCount, comboEq, isCorrect, bankPool, gapOptions } from "./exercises";
+import type { Exercise, ExerciseSentence } from "./api";
+
+function sentence(s: Partial<ExerciseSentence>): ExerciseSentence {
+  return { id: "s", text: "", answer: [], position: 0, ...s };
+}
+function exercise(e: Partial<Exercise>): Exercise {
+  return { ID: "e", CollectionID: "c", Kind: "bank", Title: "", Sentences: [], Distractors: null, Position: 0, CreatedAt: "", UpdatedAt: "", ...e };
+}
+
+describe("segments / blankCount", () => {
+  it("splits around blanks", () => {
+    expect(segments("How ___ you?")).toEqual(["How ", " you?"]);
+    expect(blankCount("How ___ you?")).toBe(1);
+    expect(blankCount("My ___ ___ Vasiliy")).toBe(2);
+    expect(blankCount("no blanks")).toBe(0);
+  });
+});
+
+describe("comboEq / isCorrect", () => {
+  it("matches same words in order", () => {
+    expect(comboEq(["a", "b"], ["a", "b"])).toBe(true);
+    expect(comboEq(["a", "b"], ["b", "a"])).toBe(false);
+    expect(comboEq(["a"], ["a", "b"])).toBe(false);
+    expect(isCorrect(["geht", "Hause"], ["geht", "Hause"])).toBe(true);
+    expect(isCorrect(["geht", "Hause"], ["geht", "Schule"])).toBe(false);
+    expect(isCorrect(["are"], [""])).toBe(false);
+  });
+});
+
+describe("bankPool", () => {
+  it("collects every answer plus distractors, keeping duplicates", () => {
+    const ex = exercise({
+      Sentences: [sentence({ answer: ["name", "is"] }), sentence({ answer: ["is"] })],
+      Distractors: ["am", "was"],
+    });
+    expect(bankPool(ex)).toEqual(["name", "is", "is", "am", "was"]);
+  });
+  it("works without distractors", () => {
+    const ex = exercise({ Sentences: [sentence({ answer: ["are"] })], Distractors: null });
+    expect(bankPool(ex)).toEqual(["are"]);
+  });
+});
+
+describe("gapOptions", () => {
+  it("per blank: answer word + its wrong options, de-duplicated", () => {
+    const s = sentence({
+      answer: ["goes", "by"],
+      distractors: [["go", "going"], ["on"]],
+    });
+    expect(gapOptions(s)).toEqual([["goes", "go", "going"], ["by", "on"]]);
+  });
+  it("single gap", () => {
+    const s = sentence({ answer: ["an"], distractors: [["a", "the"]] });
+    expect(gapOptions(s)).toEqual([["an", "a", "the"]]);
+  });
+  it("no distractors → just the answer per gap", () => {
+    expect(gapOptions(sentence({ answer: ["geht", "Hause"] }))).toEqual([["geht"], ["Hause"]]);
+  });
+});

--- a/lib/exercises.ts
+++ b/lib/exercises.ts
@@ -1,0 +1,37 @@
+// Pure helpers for the exercise worksheet (no React/DOM) — unit-tested in exercises.test.ts.
+import { Exercise, ExerciseSentence } from "./api";
+
+// Static text segments around the blanks; N blanks → N+1 segments.
+export function segments(text: string): string[] {
+  return text.split("___");
+}
+
+// Number of "___" blanks in a sentence.
+export function blankCount(text: string): number {
+  return segments(text).length - 1;
+}
+
+// Ordered equality of two word combinations.
+export function comboEq(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((w, i) => w === b[i]);
+}
+
+// Whether a submitted combination matches the expected answer.
+export function isCorrect(answer: string[], submitted: string[]): boolean {
+  return comboEq(answer, submitted);
+}
+
+// Words making up a bank exercise's shared pool (answers of every sentence + extra
+// distractors), before shuffling. May contain duplicates (a multiset).
+export function bankPool(ex: Exercise): string[] {
+  const words: string[] = [];
+  ex.Sentences.forEach((s) => words.push(...s.answer));
+  if (ex.Distractors) words.push(...ex.Distractors);
+  return words;
+}
+
+// Option words for each blank of a choice sentence (unshuffled): the correct word
+// (answer[i]) plus its wrong options (distractors[i]), de-duplicated.
+export function gapOptions(s: ExerciseSentence): string[][] {
+  return s.answer.map((a, i) => Array.from(new Set([a, ...(s.distractors?.[i] ?? [])])));
+}

--- a/public/exercises-format.md
+++ b/public/exercises-format.md
@@ -1,0 +1,154 @@
+# CRAM — generating exercises with AI
+
+This guide describes the file format for CRAM **fill-in-the-blank exercises**. Give it to an
+AI (ChatGPT, Claude, Gemini, …) together with your material, and it will produce a file you
+can import into a CRAM *exercises* collection.
+
+## How to use
+
+1. Copy this entire file into your AI chat.
+2. Add your request, e.g. *"Make 10 German A1 exercises about daily routines using this format."*
+3. The AI returns a **YAML** (or **JSON**) file.
+4. In CRAM: open your exercises collection → settings → **Import YAML** → paste it → Import.
+
+Both YAML and JSON are accepted by the importer.
+
+---
+
+## Example (B2 — ready to import)
+
+A complete file with one `bank` and one `choice` exercise. Paste it as-is to try the importer,
+or use it as a template.
+
+```yaml
+- type: bank
+  title: "Dependent prepositions"
+  sentences:
+    - text: "She's exceptionally good ___ negotiating contracts."
+      answer: [at]
+    - text: "He is solely responsible ___ the marketing budget."
+      answer: [for]
+    - text: "Several board members objected ___ the proposal."
+      answer: [to]
+    - text: "I'm slightly concerned ___ the tight deadline."
+      answer: [about]
+  distractors: [in, with, of]
+
+- type: choice
+  title: "Collocations & word choice"
+  sentences:
+    - text: "The latest figures ___ doubt on the company's strategy."
+      answer: [cast]
+      distractors: [[threw, put, made]]
+    - text: "We made a ___ decision to delay the launch."
+      answer: [conscious]
+      distractors: [[conscience, sensible, sensitive]]
+    - text: "___ hard she tried, she couldn't ___ the deadline."
+      answer: [However, meet]
+      distractors:
+        - [Although, Whatever, Despite]
+        - [make, reach, catch]
+```
+
+---
+
+## Format
+
+A file is a **list of exercises**. There are two kinds (`type`):
+
+- **`bank`** — all sentences in the exercise share one shuffled word pool; the learner drags
+  (or taps) words from the pool into the gaps. Each word is used once.
+- **`choice`** — the learner picks the correct word for each gap from an inline dropdown.
+
+### Exercise fields
+
+| field | required | applies to | meaning |
+|-------|----------|-----------|---------|
+| `type` | yes | both | `"bank"` or `"choice"` |
+| `title` | no | both | short label shown above the block |
+| `sentences` | yes | both | list of sentences (see below) |
+| `distractors` | no | **bank** only | extra words added to the shared pool (so the last gap can't be guessed) |
+
+### Sentence fields
+
+| field | required | applies to | meaning |
+|-------|----------|-----------|---------|
+| `text` | yes | both | the sentence; write `___` (three underscores) for each gap |
+| `answer` | yes | both | list of the correct word for each gap, **in order** |
+| `distractors` | no | **choice** only | wrong options **per gap**: `distractors[i]` is the list of wrong words for gap `i` |
+
+### Rules (important)
+
+- The number of items in `answer` **must equal** the number of `___` in `text`.
+- **One gap = one independent answer.** Use several `___` in a sentence **only when there is
+  real text between the gaps** (e.g. `"She ___ to work ___ bus"` → `[goes, by]`). If a whole
+  phrase fills a single slot, use **one** `___` with the phrase as the answer — e.g.
+  `"Yesterday ___ to the park."` → `answer: ["we went"]`, **not** two adjacent gaps.
+- **choice**: `distractors` is one list per gap, in the same order as `answer`
+  (so `distractors` has the same length as `answer`). Each gap's choices are its `answer`
+  word plus its wrong words. The correct word is taken from `answer` — don't repeat it in
+  `distractors`.
+- **bank**: do *not* put `distractors` on a sentence; extra pool words go in the
+  exercise-level `distractors`.
+- Keep words short (single tokens work best for the gaps).
+
+---
+
+## YAML example
+
+```yaml
+- type: bank
+  title: "Verb 'to be'"
+  sentences:
+    - text: "How ___ you?"
+      answer: [are]
+    - text: "My ___ ___ Vasiliy"
+      answer: [name, is]
+  distractors: [am, was]
+
+- type: choice
+  title: "Articles & prepositions"
+  sentences:
+    - text: "I saw ___ elephant"            # single gap
+      answer: [an]
+      distractors: [[a, the, some]]
+    - text: "She ___ to work ___ bus"       # two gaps with text between them
+      answer: [goes, by]
+      distractors:
+        - [go, going]                        # wrong options for gap 1
+        - [on]                               # wrong options for gap 2
+```
+
+## JSON example (same data)
+
+```json
+[
+  {
+    "type": "bank",
+    "title": "Verb 'to be'",
+    "sentences": [
+      { "text": "How ___ you?", "answer": ["are"] },
+      { "text": "My ___ ___ Vasiliy", "answer": ["name", "is"] }
+    ],
+    "distractors": ["am", "was"]
+  },
+  {
+    "type": "choice",
+    "title": "Articles & prepositions",
+    "sentences": [
+      { "text": "I saw ___ elephant", "answer": ["an"], "distractors": [["a", "the", "some"]] },
+      { "text": "She ___ to work ___ bus", "answer": ["goes", "by"],
+        "distractors": [["go", "going"], ["on"]] }
+    ]
+  }
+]
+```
+
+---
+
+## Ready-to-use prompt
+
+> You are generating a **CRAM exercises** file. Follow the format in the document above
+> **exactly**. Create **<N>** exercises about **<topic>** for level **<level>**, mixing `bank`
+> and `choice` types. Each sentence must use `___` for gaps, and `answer` length must equal
+> the number of gaps. Output **only** the YAML (or JSON) — no explanations, no code fences.


### PR DESCRIPTION
Frontend for the new `exercises` collection type (pairs with cram-back#18).

## What's included
- **Worksheet** (`ExerciseWorksheet.tsx`): entering an exercises collection is the interactive sheet.
  - `bank` — shared word pool, drag-and-drop or tap into gaps.
  - `choice` — an inline dropdown per gap.
  - Per-block `Confirm` → `Reset`; desktop shows all blocks, mobile is a stepper (Prev / Skip·Reset / Confirm·Next) with swipe.
  - Answered state is saved and restored on reload.
- **Authoring**: create exercises collections; YAML/JSON import panel with `imported / skipped` feedback; **Edit** panel to delete exercises; a downloadable **AI format guide** (`public/exercises-format.md`) with a ready B2 example.
- **Refactor + tests**: pure logic in `lib/exercises.ts` + vitest.

## Drive-by fixes
- Navbar SSR **hydration mismatch** (localStorage `logged_in` → `useSyncExternalStore`).
- Blitz **"See results" shown twice** (label used original count, not the live queue with requeued items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)