### PR TITLE
Connect exercise, 🎮 mini-game menu, match polish

### DIFF
--- a/app/collections/[id]/connect/page.tsx
+++ b/app/collections/[id]/connect/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { api, Card } from "@/lib/api";
+import { isLoggedIn } from "@/lib/auth";
+import Navbar from "@/components/Navbar";
+import { buildConnectBoard, type ConnectTile } from "@/lib/connect";
+
+const cardIdOf = (tileId: string) => tileId.split(":")[0];
+
+export default function ConnectPage(props: PageProps<"/collections/[id]/connect">) {
+  const [collectionID, setCollectionID] = useState("");
+  const [cards, setCards] = useState<Card[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [terms, setTerms] = useState<ConnectTile[]>([]);
+  const [definitions, setDefinitions] = useState<ConnectTile[]>([]);
+  const [connections, setConnections] = useState<Record<string, string>>({}); // termId -> defId
+  const [selectedTerm, setSelectedTerm] = useState<string | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const defRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const [lines, setLines] = useState<{ termId: string; defId: string; x1: number; y1: number; x2: number; y2: number }[]>([]);
+  const [tick, setTick] = useState(0); // bumped on resize to recompute line coords
+
+  useEffect(() => {
+    props.params.then(({ id }) => {
+      setCollectionID(id);
+      return isLoggedIn() ? api.collections.get(id) : api.collections.getPublic(id);
+    }).then((c) => {
+      const cs = c.Cards ?? [];
+      setCards(cs);
+      const board = buildConnectBoard(cs);
+      setTerms(board.terms);
+      setDefinitions(board.definitions);
+    }).catch(() => setError("Failed to load cards"));
+  }, [props.params]);
+
+  const restart = useCallback(() => {
+    if (!cards) return;
+    const board = buildConnectBoard(cards);
+    setTerms(board.terms);
+    setDefinitions(board.definitions);
+    setConnections({});
+    setSelectedTerm(null);
+    setChecked(false);
+  }, [cards]);
+
+  const tryAgain = useCallback(() => {
+    setConnections({});
+    setSelectedTerm(null);
+    setChecked(false);
+  }, []);
+
+  // Recompute line endpoints (term right-center → def left-center) after layout.
+  useEffect(() => {
+    const c = containerRef.current;
+    if (!c) return;
+    const cr = c.getBoundingClientRect();
+    const next: typeof lines = [];
+    for (const [termId, defId] of Object.entries(connections)) {
+      const tEl = termRefs.current[termId];
+      const dEl = defRefs.current[defId];
+      if (!tEl || !dEl) continue;
+      const tr = tEl.getBoundingClientRect();
+      const dr = dEl.getBoundingClientRect();
+      next.push({
+        termId, defId,
+        x1: tr.right - cr.left, y1: tr.top + tr.height / 2 - cr.top,
+        x2: dr.left - cr.left, y2: dr.top + dr.height / 2 - cr.top,
+      });
+    }
+    setLines(next);
+  }, [connections, terms, definitions, checked, tick]);
+
+  useEffect(() => {
+    const onResize = () => setTick((t) => t + 1);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const connectedCount = Object.keys(connections).length;
+  const allConnected = terms.length > 0 && connectedCount === terms.length;
+  const isCorrectTerm = (t: ConnectTile) => { const d = connections[t.id]; return !!d && cardIdOf(d) === t.cardId; };
+  const correctCount = terms.filter(isCorrectTerm).length;
+
+  function onTerm(id: string) {
+    if (checked) return;
+    setSelectedTerm((prev) => (prev === id ? null : id));
+  }
+  function onDef(id: string) {
+    if (checked) return;
+    if (selectedTerm) {
+      setConnections((prev) => {
+        const next = { ...prev };
+        for (const t of Object.keys(next)) if (next[t] === id) delete next[t]; // a def links to one term
+        next[selectedTerm] = id;
+        return next;
+      });
+      setSelectedTerm(null);
+    } else {
+      // no term selected → clicking a linked definition disconnects it
+      setConnections((prev) => {
+        const next = { ...prev };
+        let changed = false;
+        for (const t of Object.keys(next)) if (next[t] === id) { delete next[t]; changed = true; }
+        return changed ? next : prev;
+      });
+    }
+  }
+
+  function check() {
+    if (!allConnected || checked) return;
+    setChecked(true);
+    // Level up correct cards, level down wrong ones — same spaced-rep driver as blitz.
+    if (isLoggedIn()) {
+      for (const t of terms) {
+        api.progress.update(collectionID, "card", t.cardId, isCorrectTerm(t), 0).catch(() => {});
+      }
+    }
+  }
+
+  const backLink = (
+    <div className="flex justify-center pb-10">
+      <Link
+        href={collectionID ? `/collections/${collectionID}` : "/collections"}
+        className="inline-flex items-center gap-1 text-sm font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+      >
+        ← Back to collection
+      </Link>
+    </div>
+  );
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-4">
+          <p className="text-red-500">{error}</p>
+          <button onClick={() => window.history.back()} className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline">Go back</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (cards === null) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <main className="flex-1 flex items-center justify-center px-4">
+          <div className="w-full max-w-2xl grid grid-cols-2 gap-x-16 gap-y-3 animate-pulse">
+            {Array.from({ length: 14 }).map((_, i) => <div key={i} className="h-12 rounded-xl bg-gray-100 dark:bg-slate-800" />)}
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (terms.length < 2) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-4">
+          <p className="text-gray-500 dark:text-slate-400">Connect needs at least 2 cards.</p>
+          <Link href={collectionID ? `/collections/${collectionID}` : "/collections"} className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline">Back to collection</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const tileCls = (kind: "term" | "def", tile: ConnectTile) => {
+    const connected = kind === "term" ? tile.id in connections : Object.values(connections).includes(tile.id);
+    const correct = kind === "term" ? isCorrectTerm(tile) : (() => {
+      const termId = Object.keys(connections).find((t) => connections[t] === tile.id);
+      return !!termId && cardIdOf(termId) === tile.cardId;
+    })();
+    const base = "min-h-12 rounded-xl border px-3 py-2 text-sm text-center break-words transition-colors select-none";
+    if (checked) {
+      return `${base} ${connected && correct ? "border-green-400 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300" : "border-red-400 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-300"} cursor-default`;
+    }
+    if (kind === "term" && selectedTerm === tile.id) {
+      return `${base} border-indigo-500 bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 ring-2 ring-indigo-400 cursor-pointer`;
+    }
+    if (connected) {
+      return `${base} border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-300 cursor-pointer`;
+    }
+    return `${base} border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-gray-800 dark:text-slate-200 hover:border-indigo-300 dark:hover:border-indigo-600 cursor-pointer`;
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="max-w-2xl mx-auto w-full px-4 py-8 flex-1">
+        <div className="flex items-center justify-between mb-1">
+          <h1 className="text-lg font-semibold text-gray-800 dark:text-slate-200">Connect the pairs</h1>
+          <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-slate-400">
+            {checked
+              ? <span>{correctCount} / {terms.length} correct</span>
+              : <span>{connectedCount} / {terms.length} linked</span>}
+            <button onClick={restart} className="font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Restart</button>
+          </div>
+        </div>
+        <p className="text-xs text-gray-400 dark:text-slate-500 mb-4">Click a term, then its definition to link them.</p>
+
+        <div ref={containerRef} className="relative">
+          <svg className="absolute inset-0 w-full h-full pointer-events-none z-10" data-testid="connect-lines">
+            {lines.map((l) => {
+              const stroke = checked
+                ? (cardIdOf(l.termId) === cardIdOf(l.defId) ? "#22c55e" : "#ef4444")
+                : "#818cf8";
+              // Cubic Bézier with control points on the horizontal midline → a smooth S-curve.
+              const mx = (l.x1 + l.x2) / 2;
+              const d = `M ${l.x1} ${l.y1} C ${mx} ${l.y1}, ${mx} ${l.y2}, ${l.x2} ${l.y2}`;
+              return <path key={l.termId} d={d} fill="none" stroke={stroke} strokeWidth={2} strokeLinecap="round" />;
+            })}
+          </svg>
+          <div className="grid grid-cols-2 gap-x-16 gap-y-3">
+            <div className="flex flex-col gap-3">
+              {terms.map((t) => (
+                <button key={t.id} ref={(el) => { termRefs.current[t.id] = el; }} data-testid="connect-term" onClick={() => onTerm(t.id)} disabled={checked} className={tileCls("term", t)}>{t.text}</button>
+              ))}
+            </div>
+            <div className="flex flex-col gap-3">
+              {definitions.map((d) => (
+                <button key={d.id} ref={(el) => { defRefs.current[d.id] = el; }} data-testid="connect-def" onClick={() => onDef(d.id)} disabled={checked} className={tileCls("def", d)}>{d.text}</button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-center mt-6">
+          {checked ? (
+            <button onClick={tryAgain} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 transition-colors">Try again</button>
+          ) : (
+            <button onClick={check} disabled={!allConnected} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors">Check</button>
+          )}
+        </div>
+      </main>
+      {backLink}
+    </div>
+  );
+}

--- a/app/collections/[id]/match/page.tsx
+++ b/app/collections/[id]/match/page.tsx
@@ -7,7 +7,7 @@ import { isLoggedIn } from "@/lib/auth";
 import Navbar from "@/components/Navbar";
 import { buildMatchBoard, type MatchTile } from "@/lib/match";
 
-const MISMATCH_MS = 900; // how long a mismatched pair stays revealed before flipping back
+const MISMATCH_MS = 1200; // how long a mismatched pair stays revealed before flipping back
 
 export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
   const [collectionID, setCollectionID] = useState("");
@@ -19,7 +19,7 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
   const [matched, setMatched] = useState<Set<string>>(new Set());
   const [moves, setMoves] = useState(0);
   const [lock, setLock] = useState(false);                // input frozen during a mismatch reveal
-  const [termsOnLeft, setTermsOnLeft] = useState(true);   // which side holds the terms (randomized per game)
+  const [wrong, setWrong] = useState<Set<string>>(new Set()); // the two tiles of a wrong pair (blink red)
 
   useEffect(() => {
     props.params.then(({ id }) => {
@@ -29,16 +29,15 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
       const cs = c.Cards ?? [];
       setCards(cs);
       setTiles(buildMatchBoard(cs));
-      setTermsOnLeft(Math.random() < 0.5);
     }).catch(() => setError("Failed to load cards"));
   }, [props.params]);
 
   const restart = useCallback(() => {
     if (!cards) return;
     setTiles(buildMatchBoard(cards));
-    setTermsOnLeft(Math.random() < 0.5);
     setFlipped([]);
     setMatched(new Set());
+    setWrong(new Set());
     setMoves(0);
     setLock(false);
   }, [cards]);
@@ -47,16 +46,18 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
   const matchedPairs = matched.size / 2;
   const solved = tiles.length > 0 && matched.size === tiles.length;
 
-  // Terms on one side, definitions on the other; which side is randomized per game.
-  const termTiles = tiles.filter((t) => t.side === "term");
-  const defTiles = tiles.filter((t) => t.side === "definition");
-  const leftTiles = termsOnLeft ? termTiles : defTiles;
-  const rightTiles = termsOnLeft ? defTiles : termTiles;
-  const leftLabel = termsOnLeft ? "Terms" : "Definitions";
-  const rightLabel = termsOnLeft ? "Definitions" : "Terms";
+  // Terms always on the left, definitions on the right.
+  const leftTiles = tiles.filter((t) => t.side === "term");
+  const rightTiles = tiles.filter((t) => t.side === "definition");
+  const leftLabel = "Terms";
+  const rightLabel = "Definitions";
 
   function onTile(id: string) {
     if (lock || matched.has(id) || flipped.includes(id)) return;
+    const tile = tiles.find((t) => t.id === id)!;
+    // Once a tile on a side is open, that side is locked — the next pick must come
+    // from the other side. A pair is only evaluated with one tile from each side.
+    if (flipped.some((fid) => tiles.find((t) => t.id === fid)!.side === tile.side)) return;
     const next = [...flipped, id];
     setFlipped(next);
     if (next.length < 2) return;
@@ -68,13 +69,15 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
       setFlipped([]);
     } else {
       setLock(true);
-      setTimeout(() => { setFlipped([]); setLock(false); }, MISMATCH_MS);
+      setWrong(new Set([a.id, b.id]));
+      setTimeout(() => { setFlipped([]); setWrong(new Set()); setLock(false); }, MISMATCH_MS);
     }
   }
 
   const renderTile = (t: MatchTile) => {
     const isMatched = matched.has(t.id);
-    const isUp = isMatched || flipped.includes(t.id);
+    const isWrong = wrong.has(t.id);
+    const isUp = isMatched || isWrong || flipped.includes(t.id);
     return (
       <button
         key={t.id}
@@ -87,6 +90,8 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
         className={`min-h-24 sm:min-h-28 rounded-xl border p-2 text-center flex items-center justify-center transition-colors select-none ${
           isMatched
             ? "border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20 opacity-50 cursor-default"
+            : isWrong
+            ? "border-red-400 bg-white dark:bg-slate-900 match-wrong"
             : isUp
             ? "border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20"
             : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:border-indigo-300 dark:hover:border-indigo-600 hover:bg-gray-50 dark:hover:bg-slate-800 cursor-pointer"
@@ -169,12 +174,12 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
 
         {/* Two halves split by a vertical divider: terms one side, definitions the other. */}
         <div className="flex items-stretch gap-3 sm:gap-5">
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0" data-testid="match-side">
             <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-slate-500 mb-2 text-center">{leftLabel}</p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">{leftTiles.map(renderTile)}</div>
           </div>
           <div className="w-px bg-gray-200 dark:bg-slate-700 self-stretch" />
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0" data-testid="match-side">
             <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-slate-500 mb-2 text-center">{rightLabel}</p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">{rightTiles.map(renderTile)}</div>
           </div>

--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -62,6 +62,55 @@ function IconBtn({ emoji, title, onClick, danger, type = "button", form, disable
   );
 }
 
+// Mini-games playable over a collection's cards. Add new ones here — they show up
+// in the 🎮 menu and in the 🎲 Random pick automatically.
+const MINI_GAMES: { emoji: string; label: string; slug: string }[] = [
+  { emoji: "🃏", label: "Match", slug: "match" },
+  { emoji: "🔗", label: "Connect", slug: "connect" },
+];
+
+// 🎮 menu next to Blitz: pick a mini-game (🎲 Random first). Disabled when the
+// collection has too few cards to play.
+function GamesMenu({ collectionID, disabled }: { collectionID: string; disabled?: boolean }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const go = (slug: string) => { setOpen(false); router.push(`/collections/${collectionID}/${slug}`); };
+  const random = () => go(MINI_GAMES[Math.floor(Math.random() * MINI_GAMES.length)].slug);
+  const itemCls = "w-full text-left px-3 py-1.5 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-800";
+
+  if (disabled) {
+    return <span title="Needs at least 5 cards" className="px-4 py-2 rounded-lg text-sm border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-400 dark:text-slate-600 cursor-not-allowed">🎮</span>;
+  }
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title="Mini games"
+        aria-label="Mini games"
+        className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+      >
+        🎮
+      </button>
+      {open && (
+        <div className="absolute z-20 mt-1 left-0 min-w-[10rem] rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg py-1">
+          <button onClick={random} className={itemCls}>🎲 Random</button>
+          {MINI_GAMES.map((g) => (
+            <button key={g.slug} onClick={() => go(g.slug)} className={itemCls}>{g.emoji} {g.label}</button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Form fields box (used inside CardForm/TestForm; Save/Cancel live in a side panel).
 const formBox = "bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-4 flex flex-col gap-3 flex-1 min-w-0";
 
@@ -1068,15 +1117,9 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
                 </Link>
               )
             )}
+            {cards.length >= 1 && <GamesMenu collectionID={collection.ID} disabled={!hasMatch} />}
             {hasFlip && (
               <Link href={`/collections/${collection.ID}/cards`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Cards</Link>
-            )}
-            {cards.length >= 1 && (
-              hasMatch ? (
-                <Link href={`/collections/${collection.ID}/match`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Match</Link>
-              ) : (
-                <span title="Needs at least 5 cards" className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 text-gray-400 dark:text-slate-600 px-4 py-2 rounded-lg text-sm font-medium cursor-not-allowed">Match</span>
-              )
             )}
             {hasExercises && (
               <Link href={`/collections/${collection.ID}/exercises`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Exercise</Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Matching game: a wrong pair flashes its border red twice before flipping back. */
+@keyframes match-wrong {
+  0%, 50%, 100% { border-color: #ef4444; }
+  25%, 75%      { border-color: #e5e7eb; }
+}
+.match-wrong {
+  animation: match-wrong 0.9s ease-in-out;
+}

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -221,9 +221,11 @@ test("Match game: enabled with ≥5 cards, board renders and tiles flip", async 
   const expectedTiles = 2 * Math.min(cardCount, 10);
 
   await page.goto(`/collections/${go!.ID}`);
-  const matchLink = page.getByRole("link", { name: "Match" });
-  await expect(matchLink).toBeVisible({ timeout: 30_000 });
-  await matchLink.click();
+  // Match lives in the 🎮 games menu now.
+  const gamesBtn = page.getByRole("button", { name: "Mini games" });
+  await expect(gamesBtn).toBeVisible({ timeout: 30_000 });
+  await gamesBtn.click();
+  await page.getByRole("button", { name: /Match/ }).click();
   await page.waitForURL(/\/match$/);
 
   const tiles = page.getByTestId("match-tile");
@@ -236,6 +238,27 @@ test("Match game: enabled with ≥5 cards, board renders and tiles flip", async 
   await expect(first).toHaveAttribute("data-facing", "up");
 });
 
+test("Match game: only one tile per side can be face-up (no same-side pair)", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+
+  await page.goto(`/collections/${go!.ID}/match`);
+  const side = page.getByTestId("match-side").first();
+  const sideTiles = side.getByTestId("match-tile");
+  await expect(sideTiles.first()).toBeVisible({ timeout: 30_000 });
+
+  // Click two tiles on the SAME side — the selection moves, it does not form a pair.
+  await sideTiles.nth(0).click();
+  await sideTiles.nth(1).click();
+
+  // Exactly one tile on this side is face-up, and no move was counted.
+  await expect(side.locator('[data-testid="match-tile"][data-facing="up"]')).toHaveCount(1);
+  await expect(page.getByText("0 moves")).toBeVisible();
+});
+
 test("Match game: inactive when a collection has fewer than 5 cards", async ({ page }) => {
   test.setTimeout(60_000);
   await login(page);
@@ -246,9 +269,35 @@ test("Match game: inactive when a collection has fewer than 5 cards", async ({ p
   expect((detail.Cards ?? []).length, "Private Notes should have <5 cards").toBeLessThan(5);
 
   await page.goto(`/collections/${pn!.ID}`);
-  // Match is shown but inactive — rendered as plain text, not a link.
-  await expect(page.getByText("Match", { exact: true })).toBeVisible({ timeout: 30_000 });
-  await expect(page.getByRole("link", { name: "Match" })).toHaveCount(0);
+  // The 🎮 games menu is shown but inactive — rendered as plain text, not a button.
+  await expect(page.getByText("🎮")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Mini games" })).toHaveCount(0);
+});
+
+test("Connect game: link matching pairs via the 🎮 menu, Check reports all correct", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+  const detail = await (await page.request.get(`${API}/collections/${go!.ID}`)).json();
+  const cards = (detail.Cards ?? []) as Array<{ Term: string; Definition: string }>;
+  expect(cards.length, "Go Basics ≤7 cards so all show on the board").toBeGreaterThanOrEqual(2);
+  expect(cards.length).toBeLessThanOrEqual(7);
+
+  await page.goto(`/collections/${go!.ID}`);
+  await page.getByRole("button", { name: "Mini games" }).click();
+  await page.getByRole("button", { name: /Connect/ }).click();
+  await page.waitForURL(/\/connect$/);
+  await expect(page.getByTestId("connect-term")).toHaveCount(cards.length, { timeout: 30_000 });
+
+  // Link each card's term to its definition (both are visible on the board).
+  for (const c of cards) {
+    await page.getByTestId("connect-term").filter({ hasText: c.Term }).first().click();
+    await page.getByTestId("connect-def").filter({ hasText: c.Definition }).first().click();
+  }
+  await page.getByRole("button", { name: "Check" }).click();
+  await expect(page.getByText(`${cards.length} / ${cards.length} correct`)).toBeVisible({ timeout: 10_000 });
 });
 
 test("blitz session loads a card question", async ({ page }) => {

--- a/lib/connect.test.ts
+++ b/lib/connect.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { buildConnectBoard } from "./connect";
+import type { Card } from "./api";
+
+function card(p: Partial<Card>): Card {
+  return { ID: "c", CollectionID: "col", Term: "t", Definition: "d", Image: "", Position: 0, CreatedAt: "", UpdatedAt: "", ...p } as Card;
+}
+const cards = (n: number) => Array.from({ length: n }, (_, i) => card({ ID: `c${i}`, Term: `term${i}`, Definition: `def${i}` }));
+
+describe("buildConnectBoard", () => {
+  it("caps at max pairs and mirrors terms/definitions by cardId", () => {
+    const { terms, definitions } = buildConnectBoard(cards(10), 7);
+    expect(terms).toHaveLength(7);
+    expect(definitions).toHaveLength(7);
+    expect(new Set(terms.map((t) => t.cardId))).toEqual(new Set(definitions.map((d) => d.cardId)));
+  });
+
+  it("uses all cards when fewer than max", () => {
+    const { terms, definitions } = buildConnectBoard(cards(3), 7);
+    expect(terms).toHaveLength(3);
+    expect(definitions).toHaveLength(3);
+  });
+
+  it("term tiles carry terms, definition tiles carry definitions", () => {
+    const { terms, definitions } = buildConnectBoard([card({ ID: "x", Term: "goroutine", Definition: "a thread" })], 7);
+    expect(terms[0]).toMatchObject({ cardId: "x", text: "goroutine", id: "x:t" });
+    expect(definitions[0]).toMatchObject({ cardId: "x", text: "a thread", id: "x:d" });
+  });
+
+  it("skips cards missing a term or definition", () => {
+    const { terms, definitions } = buildConnectBoard([
+      card({ ID: "a", Term: "ok", Definition: "ok" }),
+      card({ ID: "b", Term: "", Definition: "no term" }),
+    ], 7);
+    expect(terms).toHaveLength(1);
+    expect(definitions).toHaveLength(1);
+    expect(terms[0].cardId).toBe("a");
+  });
+});

--- a/lib/connect.ts
+++ b/lib/connect.ts
@@ -1,0 +1,15 @@
+// Pure helper for the connect exercise (no React/DOM) — unit-tested in connect.test.ts.
+import { Card } from "./api";
+import { shuffle } from "./match";
+
+export type ConnectTile = { id: string; cardId: string; text: string };
+
+// Pick up to `max` cards with both sides, then build two independently-shuffled
+// columns (terms, definitions) so matching pairs don't line up by row.
+export function buildConnectBoard(cards: Card[], max = 7): { terms: ConnectTile[]; definitions: ConnectTile[] } {
+  const usable = cards.filter((c) => c.Term?.trim() && c.Definition?.trim());
+  const picked = shuffle(usable).slice(0, Math.max(0, max));
+  const terms = shuffle(picked.map((c) => ({ id: `${c.ID}:t`, cardId: c.ID, text: c.Term })));
+  const definitions = shuffle(picked.map((c) => ({ id: `${c.ID}:d`, cardId: c.ID, text: c.Definition })));
+  return { terms, definitions };
+}


### PR DESCRIPTION
## Mini-games
- **🎮 games menu** next to Blitz: **🎲 Random** first, then the mini-games (🃏 Match, 🔗 Connect). Inactive when the collection has <5 cards. New games are one line in `MINI_GAMES`.
- **Connect exercise** (`/collections/[id]/connect`): terms on the left, definitions on the right, both open and independently shuffled. **Click a term, then its definition** to link them — drawn as smooth **curved (Bézier) lines**. **Check** colors both the lines **and the tile borders** green/red and reports `N/M correct`; up to **7 pairs**. Try again / Restart.
- **Spaced-rep level up/down**: on Check, each source card is leveled up (correct link) or down (wrong/unlinked) via the same `api.progress.update` the blitz driver uses. Logged-in only.

## Match polish
- Wrong pair **blinks its border red twice** (border only, no fill).
- **One selection per side** — opening a tile locks that side; the next pick must come from the other side.
- Terms always on the left; mismatch reveal 1.2s.

## Tests
- Unit: `buildConnectBoard`.
- e2e: 🎮 menu → Connect (link every pair → Check → all correct, exercising the level-up path); match side-locking.

Checks: tsc clean · vitest 30/30 · e2e 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)