### PR TITLE
Settings: MCP access, and the OAuth consent screen

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -3,13 +3,16 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { markLoggedIn } from "@/lib/auth";
+import { takeReturnTo } from "@/lib/returnTo";
 
 export default function AuthCallback() {
   const router = useRouter();
 
   useEffect(() => {
     markLoggedIn();
-    router.replace("/collections");
+    // A page that needed a signed-in user (the OAuth consent screen) parks where to come back
+    // to, because Google always returns here.
+    router.replace(takeReturnTo() ?? "/collections");
   }, [router]);
 
   return (

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Navbar from "@/components/Navbar";
+import { api } from "@/lib/api";
+import { useCurrentUser } from "@/contexts/UserContext";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+// What each scope actually allows, in the words a user can act on. "read_write" is deliberately
+// blunt: an approval here lets a third-party app change study material.
+const SCOPE_TEXT: Record<string, { title: string; points: string[] }> = {
+  read: {
+    title: "Read your collections",
+    points: ["See your collections and everything in them", "See your study progress"],
+  },
+  read_write: {
+    title: "Read and change your collections",
+    points: [
+      "See your collections and everything in them",
+      "See your study progress",
+      "Create collections and add cards, quizzes and exercises",
+      "Publish or discard changes staged for review",
+    ],
+  },
+};
+
+function ConsentScreen() {
+  const params = useSearchParams();
+  const currentUser = useCurrentUser();
+  const [busy, setBusy] = useState<"approve" | "deny" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const clientName = params.get("client_name") || "An application";
+  const scope = params.get("scope") === "read_write" ? "read_write" : "read";
+  const redirectURI = params.get("redirect_uri") ?? "";
+  const detail = SCOPE_TEXT[scope];
+
+  // The host is the one fact that distinguishes a real client from a lookalike, so it is shown
+  // rather than hidden behind the client's self-declared name.
+  let redirectHost = redirectURI;
+  try {
+    redirectHost = new URL(redirectURI).host || redirectURI;
+  } catch {
+    /* keep the raw value: an unparseable URI is itself worth seeing */
+  }
+
+  async function decide(approved: boolean) {
+    setBusy(approved ? "approve" : "deny");
+    setError(null);
+    try {
+      const { redirect_to } = await api.oauth.approve({
+        client_id: params.get("client_id") ?? "",
+        redirect_uri: redirectURI,
+        scope,
+        state: params.get("state") ?? "",
+        code_challenge: params.get("code_challenge") ?? "",
+        code_challenge_method: params.get("code_challenge_method") ?? "S256",
+        resource: params.get("resource") ?? "",
+        approved,
+      });
+      window.location.href = redirect_to;
+    } catch {
+      setError("Could not complete the request. Try starting the connection again from the app.");
+      setBusy(null);
+    }
+  }
+
+  if (!params.get("client_id") || !redirectURI) {
+    return (
+      <p className="text-sm text-red-500">
+        This link is incomplete. Start the connection from the application again.
+      </p>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-6">
+      <h1 className="text-lg font-bold text-gray-900 dark:text-slate-100 mb-1">
+        Connect <span className="text-indigo-600 dark:text-indigo-400">{clientName}</span> to Cram?
+      </h1>
+      <p className="text-xs text-gray-500 dark:text-slate-400 mb-4">
+        Signed in as {currentUser?.email ?? "your account"}. The application will act as you.
+      </p>
+
+      <div className="rounded-lg border border-gray-200 dark:border-slate-700 p-4 mb-4">
+        <p className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">{detail.title}</p>
+        <ul className="flex flex-col gap-1">
+          {detail.points.map((p) => (
+            <li key={p} className="text-xs text-gray-600 dark:text-slate-400 flex gap-2">
+              <span aria-hidden="true">·</span>
+              {p}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-slate-400 mb-1">
+        After approving, you will be sent to <span className="font-mono">{redirectHost}</span>.
+      </p>
+      <p className="text-xs text-gray-500 dark:text-slate-400 mb-5">
+        You can disconnect it at any time in Settings.
+      </p>
+
+      <div className="flex gap-2">
+        <button
+          onClick={() => decide(true)}
+          disabled={busy !== null}
+          className="h-10 text-sm font-medium px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-40"
+        >
+          {busy === "approve" ? "Connecting…" : "Approve"}
+        </button>
+        <button
+          onClick={() => decide(false)}
+          disabled={busy !== null}
+          className="h-10 text-sm font-medium px-4 rounded-lg border border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:border-gray-400 transition-colors disabled:opacity-40"
+        >
+          {busy === "deny" ? "Cancelling…" : "Cancel"}
+        </button>
+      </div>
+
+      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+export default function ConsentPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="max-w-lg mx-auto w-full px-4 py-8 flex-1">
+        {/* The session lives in a cookie on the API host; an unauthenticated visitor is sent to
+            log in and comes back to this exact URL. */}
+        <Suspense fallback={<p className="text-sm text-gray-400">Loading…</p>}>
+          <ConsentScreen />
+        </Suspense>
+        <noscript>
+          <p className="mt-4 text-sm text-red-500">This page needs JavaScript.</p>
+        </noscript>
+        <p className="mt-4 text-xs text-gray-400 dark:text-slate-500">
+          Not signed in?{" "}
+          <a className="text-indigo-600 dark:text-indigo-400 hover:underline" href={`${API_URL}/auth/google`}>
+            Sign in
+          </a>{" "}
+          and open this link again.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Navbar from "@/components/Navbar";
 import { api } from "@/lib/api";
-import { useCurrentUser } from "@/contexts/UserContext";
+import { rememberReturnTo } from "@/lib/returnTo";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 
@@ -28,9 +28,33 @@ const SCOPE_TEXT: Record<string, { title: string; points: string[] }> = {
 
 function ConsentScreen() {
   const params = useSearchParams();
-  const currentUser = useCurrentUser();
   const [busy, setBusy] = useState<"approve" | "deny" | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // The session is checked here, before anything is shown, rather than at the moment Approve is
+  // pressed. A 401 on approve would send the user to the home page and take the authorization
+  // parameters with it, leaving them to start the connection over in the client application.
+  const [account, setAccount] = useState<{ email: string } | null | "checking">("checking");
+  useEffect(() => {
+    let active = true;
+    api.auth
+      .session()
+      .then((me) => {
+        if (active) setAccount({ email: me.email });
+      })
+      .catch(() => {
+        if (active) setAccount(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function signIn() {
+    // Google's callback always lands on /auth/callback, so park where to come back to.
+    rememberReturnTo(window.location.pathname + window.location.search);
+    window.location.href = `${API_URL}/auth/google`;
+  }
 
   const clientName = params.get("client_name") || "An application";
   const scope = params.get("scope") === "read_write" ? "read_write" : "read";
@@ -61,8 +85,14 @@ function ConsentScreen() {
         approved,
       });
       window.location.href = redirect_to;
-    } catch {
-      setError("Could not complete the request. Try starting the connection again from the app.");
+    } catch (e) {
+      // The cookie can lapse between opening the page and pressing the button; that is a
+      // sign-in prompt, not a dead end.
+      if (e instanceof Error && /unauthorized/i.test(e.message)) {
+        setAccount(null);
+      } else {
+        setError("Could not complete the request. Try starting the connection again from the app.");
+      }
       setBusy(null);
     }
   }
@@ -75,13 +105,37 @@ function ConsentScreen() {
     );
   }
 
+  if (account === "checking") {
+    return <p className="text-sm text-gray-400 dark:text-slate-500">Checking your session…</p>;
+  }
+
+  if (account === null) {
+    return (
+      <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-6">
+        <h1 className="text-lg font-bold text-gray-900 dark:text-slate-100 mb-1">
+          Sign in to connect {clientName}
+        </h1>
+        <p className="text-xs text-gray-500 dark:text-slate-400 mb-5">
+          You need to be signed in to Cram before you can grant access. We will bring you back to this
+          page afterwards.
+        </p>
+        <button
+          onClick={signIn}
+          className="h-10 text-sm font-medium px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+        >
+          Sign in with Google
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-6">
       <h1 className="text-lg font-bold text-gray-900 dark:text-slate-100 mb-1">
         Connect <span className="text-indigo-600 dark:text-indigo-400">{clientName}</span> to Cram?
       </h1>
       <p className="text-xs text-gray-500 dark:text-slate-400 mb-4">
-        Signed in as {currentUser?.email ?? "your account"}. The application will act as you.
+        Signed in as {account.email}. The application will act as you.
       </p>
 
       <div className="rounded-lg border border-gray-200 dark:border-slate-700 p-4 mb-4">
@@ -138,13 +192,6 @@ export default function ConsentPage() {
         <noscript>
           <p className="mt-4 text-sm text-red-500">This page needs JavaScript.</p>
         </noscript>
-        <p className="mt-4 text-xs text-gray-400 dark:text-slate-500">
-          Not signed in?{" "}
-          <a className="text-indigo-600 dark:text-indigo-400 hover:underline" href={`${API_URL}/auth/google`}>
-            Sign in
-          </a>{" "}
-          and open this link again.
-        </p>
       </main>
     </div>
   );

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api";
 import { logout } from "@/lib/auth";
 import { useCurrentUser } from "@/contexts/UserContext";
 import Navbar from "@/components/Navbar";
+import McpAccess from "@/components/McpAccess";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -46,6 +47,9 @@ export default function SettingsPage() {
             </div>
           </div>
         </section>
+
+        {/* MCP access — personal access tokens + connection snippets */}
+        <McpAccess />
 
         {/* Danger zone */}
         <section className="bg-white dark:bg-slate-900 border border-red-200 dark:border-red-900/50 rounded-xl p-6">

--- a/components/McpAccess.tsx
+++ b/components/McpAccess.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { api, type AccessToken, type TokenScope } from "@/lib/api";
+import { api, type AccessToken, type Connection, type TokenScope } from "@/lib/api";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 const MCP_URL = `${API_URL}/mcp`;
@@ -80,6 +80,11 @@ export default function McpAccess() {
   const [freshToken, setFreshToken] = useState<string | null>(null);
   const [revoking, setRevoking] = useState<string | null>(null);
 
+  // Applications connected over OAuth. Separate from tokens: the user never sees a value here,
+  // they see who they let in.
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [disconnecting, setDisconnecting] = useState<string | null>(null);
+
   // Used after a create or revoke. The initial fetch lives in the effect below, which must not
   // call setState synchronously.
   const reload = useCallback(async () => {
@@ -95,6 +100,14 @@ export default function McpAccess() {
 
   useEffect(() => {
     let active = true;
+    api.oauth
+      .connections()
+      .then((list) => {
+        if (active) setConnections(list ?? []);
+      })
+      .catch(() => {
+        /* the list is secondary; a failure here must not hide the token UI */
+      });
     api.tokens
       .list()
       .then((list) => {
@@ -141,6 +154,19 @@ export default function McpAccess() {
     }
   }
 
+  async function disconnect(id: string) {
+    setDisconnecting(id);
+    setError(null);
+    try {
+      await api.oauth.disconnect(id);
+      setConnections((prev) => prev.filter((c) => c.id !== id));
+    } catch {
+      setError("Could not disconnect the application.");
+    } finally {
+      setDisconnecting(null);
+    }
+  }
+
   const live = tokens.filter((t) => !t.revoked_at);
   const revoked = tokens.filter((t) => t.revoked_at);
 
@@ -172,13 +198,13 @@ export default function McpAccess() {
 
           <details className="mt-4">
             <summary className="text-xs font-medium text-gray-700 dark:text-slate-300 cursor-pointer">
-              Claude Desktop (workaround)
+              Claude Desktop
             </summary>
             <p className="text-xs text-gray-500 dark:text-slate-400 mt-2 mb-2">
-              Desktop connectors only speak OAuth, which Cram does not offer yet, so this route runs{" "}
-              <span className="font-mono">mcp-remote</span> — a third-party bridge we do not control — and your token
-              passes through it. Add the block to <span className="font-mono">{DESKTOP_CONFIG_PATH}</span>, then quit
-              Claude Desktop completely (⌘Q) and reopen it; closing the window is not enough.
+              Add this block to <span className="font-mono">{DESKTOP_CONFIG_PATH}</span>, then quit Claude Desktop
+              completely (⌘Q) and reopen it — closing the window does not reload the config. It runs{" "}
+              <span className="font-mono">mcp-remote</span>, an open-source bridge that connects Desktop to a remote
+              server; your token is passed to it as an environment variable.
             </p>
             <Snippet code={desktopSnippet(freshToken)} />
           </details>
@@ -202,31 +228,69 @@ export default function McpAccess() {
               onChange={(e) => setName(e.target.value)}
               maxLength={100}
               placeholder="Claude on my laptop"
-              className="w-full text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder:text-gray-400"
+              className="w-full h-10 text-sm px-3 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder:text-gray-400"
             />
           </div>
           <div>
             <label htmlFor="token-scope" className="block text-xs text-gray-500 dark:text-slate-400 mb-1">
               Access
             </label>
-            <select
-              id="token-scope"
-              value={scope}
-              onChange={(e) => setScope(e.target.value as TokenScope)}
-              className="text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
-            >
-              <option value="read_write">Read and write</option>
-              <option value="read">Read only</option>
-            </select>
+            {/* appearance-none: the native control draws its own corners and ignores the
+                radius, so it would not match the input and the button. Hence our own chevron. */}
+            <div className="relative">
+              <select
+                id="token-scope"
+                value={scope}
+                onChange={(e) => setScope(e.target.value as TokenScope)}
+                className="h-10 w-full appearance-none text-sm pl-3 pr-8 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
+              >
+                <option value="read_write">Read and write</option>
+                <option value="read">Read only</option>
+              </select>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 20 20"
+                fill="none"
+                className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-slate-500"
+              >
+                <path d="M6 8l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
           </div>
           <button
             type="submit"
             disabled={creating || !name.trim()}
-            className="text-sm font-medium px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-40"
+            className="h-10 text-sm font-medium px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-40"
           >
             {creating ? "Creating…" : "Create token"}
           </button>
         </form>
+      )}
+
+      {connections.length > 0 && (
+        <div className="mb-5">
+          <p className="text-xs font-medium text-gray-700 dark:text-slate-300 mb-2">Connected applications</p>
+          <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+            {connections.map((c) => (
+              <li key={c.id} className="py-3 flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate text-gray-900 dark:text-slate-100">{c.client_name}</p>
+                  <p className="text-xs text-gray-500 dark:text-slate-400">
+                    {c.scope === "read" ? "Read only" : "Read and write"} · connected {formatDate(c.created_at)} · last
+                    used {formatDate(c.last_used_at)}
+                  </p>
+                </div>
+                <button
+                  onClick={() => disconnect(c.id)}
+                  disabled={disconnecting === c.id}
+                  className="shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-40"
+                >
+                  {disconnecting === c.id ? "Disconnecting…" : "Disconnect"}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
 
       {loading ? (

--- a/components/McpAccess.tsx
+++ b/components/McpAccess.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { api, type AccessToken, type TokenScope } from "@/lib/api";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+const MCP_URL = `${API_URL}/mcp`;
+const DESKTOP_CONFIG_PATH = "~/Library/Application Support/Claude/claude_desktop_config.json";
+
+function claudeCodeSnippet(token: string): string {
+  return `claude mcp add --transport http cram ${MCP_URL} \\
+  --header "Authorization: Bearer ${token}"`;
+}
+
+// The header goes through an env var on purpose: passed inline, the space in
+// "Bearer <token>" is split on by some builds of the bridge.
+function desktopSnippet(token: string): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        cram: {
+          command: "npx",
+          args: ["-y", "mcp-remote", MCP_URL, "--header", "Authorization:${AUTH}"],
+          env: { AUTH: `Bearer ${token}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "never";
+  return new Date(value).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+function CopyButton({ value, label = "Copy" }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          setCopied(false);
+        }
+      }}
+      className="shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:border-gray-400 transition-colors"
+    >
+      {copied ? "Copied" : label}
+    </button>
+  );
+}
+
+function Snippet({ code }: { code: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <pre className="flex-1 min-w-0 overflow-x-auto text-[11px] leading-relaxed font-mono bg-gray-50 dark:bg-slate-950 border border-gray-200 dark:border-slate-700 rounded-lg p-3 text-gray-700 dark:text-slate-300">
+        {code}
+      </pre>
+      <CopyButton value={code} />
+    </div>
+  );
+}
+
+export default function McpAccess() {
+  const [tokens, setTokens] = useState<AccessToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState<TokenScope>("read_write");
+  const [creating, setCreating] = useState(false);
+
+  // Held in memory only — the API will never return this value again.
+  const [freshToken, setFreshToken] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  // Used after a create or revoke. The initial fetch lives in the effect below, which must not
+  // call setState synchronously.
+  const reload = useCallback(async () => {
+    try {
+      setTokens((await api.tokens.list()) ?? []);
+      setError(null);
+    } catch {
+      setError("Could not load tokens.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    api.tokens
+      .list()
+      .then((list) => {
+        if (active) setTokens(list ?? []);
+      })
+      .catch(() => {
+        if (active) setError("Could not load tokens.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await api.tokens.create(name.trim(), scope);
+      setFreshToken(created.token);
+      setName("");
+      await reload();
+    } catch {
+      setError("Could not create the token.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function revoke(id: string) {
+    setRevoking(id);
+    setError(null);
+    try {
+      await api.tokens.revoke(id);
+      await reload();
+    } catch {
+      setError("Could not revoke the token.");
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  const live = tokens.filter((t) => !t.revoked_at);
+  const revoked = tokens.filter((t) => t.revoked_at);
+
+  return (
+    <section className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-6 mb-6">
+      <h2 className="text-sm font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1">MCP access</h2>
+      <p className="text-xs text-gray-500 dark:text-slate-400 mb-4">
+        Connect an AI assistant to your collections so it can read them and add cards, quizzes and exercises for you.
+        A token acts as you — anyone holding it can do the same.
+      </p>
+
+      {freshToken ? (
+        <div className="mb-5 rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4">
+          <p className="text-xs font-medium text-amber-900 dark:text-amber-200 mb-2">
+            Copy your token now — it is shown once and cannot be retrieved later.
+          </p>
+          <div className="flex items-center gap-2 mb-4">
+            <code className="flex-1 min-w-0 truncate text-xs font-mono bg-white dark:bg-slate-900 border border-amber-200 dark:border-amber-900 rounded px-2 py-1.5 text-gray-900 dark:text-slate-100">
+              {freshToken}
+            </code>
+            <CopyButton value={freshToken} />
+          </div>
+
+          <p className="text-xs font-medium text-gray-700 dark:text-slate-300 mb-1">Claude Code</p>
+          <p className="text-xs text-gray-500 dark:text-slate-400 mb-2">
+            Run this in your terminal, then restart Claude Code.
+          </p>
+          <Snippet code={claudeCodeSnippet(freshToken)} />
+
+          <details className="mt-4">
+            <summary className="text-xs font-medium text-gray-700 dark:text-slate-300 cursor-pointer">
+              Claude Desktop (workaround)
+            </summary>
+            <p className="text-xs text-gray-500 dark:text-slate-400 mt-2 mb-2">
+              Desktop connectors only speak OAuth, which Cram does not offer yet, so this route runs{" "}
+              <span className="font-mono">mcp-remote</span> — a third-party bridge we do not control — and your token
+              passes through it. Add the block to <span className="font-mono">{DESKTOP_CONFIG_PATH}</span>, then quit
+              Claude Desktop completely (⌘Q) and reopen it; closing the window is not enough.
+            </p>
+            <Snippet code={desktopSnippet(freshToken)} />
+          </details>
+
+          <button
+            onClick={() => setFreshToken(null)}
+            className="mt-4 text-xs px-3 py-1.5 rounded-lg border border-amber-300 dark:border-amber-800 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={create} className="flex flex-wrap items-end gap-2 mb-5">
+          <div className="flex-1 min-w-40">
+            <label htmlFor="token-name" className="block text-xs text-gray-500 dark:text-slate-400 mb-1">
+              Name
+            </label>
+            <input
+              id="token-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={100}
+              placeholder="Claude on my laptop"
+              className="w-full text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 placeholder:text-gray-400"
+            />
+          </div>
+          <div>
+            <label htmlFor="token-scope" className="block text-xs text-gray-500 dark:text-slate-400 mb-1">
+              Access
+            </label>
+            <select
+              id="token-scope"
+              value={scope}
+              onChange={(e) => setScope(e.target.value as TokenScope)}
+              className="text-sm px-3 py-2 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
+            >
+              <option value="read_write">Read and write</option>
+              <option value="read">Read only</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            disabled={creating || !name.trim()}
+            className="text-sm font-medium px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-40"
+          >
+            {creating ? "Creating…" : "Create token"}
+          </button>
+        </form>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-400 dark:text-slate-500">Loading…</p>
+      ) : tokens.length === 0 ? (
+        <p className="text-sm text-gray-400 dark:text-slate-500">No tokens yet.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100 dark:divide-slate-800">
+          {[...live, ...revoked].map((t) => (
+            <li key={t.id} className="py-3 flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p
+                  className={`text-sm font-medium truncate ${
+                    t.revoked_at ? "text-gray-400 dark:text-slate-500 line-through" : "text-gray-900 dark:text-slate-100"
+                  }`}
+                >
+                  {t.name}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-slate-400">
+                  {t.scope === "read" ? "Read only" : "Read and write"} · created {formatDate(t.created_at)} · last used{" "}
+                  {formatDate(t.last_used_at)}
+                  {t.revoked_at && ` · revoked ${formatDate(t.revoked_at)}`}
+                </p>
+              </div>
+              {!t.revoked_at && (
+                <button
+                  onClick={() => revoke(t.id)}
+                  disabled={revoking === t.id}
+                  className="shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-40"
+                >
+                  {revoking === t.id ? "Revoking…" : "Revoke"}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+    </section>
+  );
+}

--- a/components/McpAccess.tsx
+++ b/components/McpAccess.tsx
@@ -134,8 +134,8 @@ export default function McpAccess() {
       setFreshToken(created.token);
       setName("");
       await reload();
-    } catch {
-      setError("Could not create the token.");
+    } catch (e) {
+      setError(e instanceof Error && e.message ? e.message : "Could not create the token.");
     } finally {
       setCreating(false);
     }
@@ -169,6 +169,9 @@ export default function McpAccess() {
 
   const live = tokens.filter((t) => !t.revoked_at);
   const revoked = tokens.filter((t) => t.revoked_at);
+  // Mirrors the server's limit; the server is still the one enforcing it.
+  const MAX_LIVE_TOKENS = 5;
+  const atLimit = live.length >= MAX_LIVE_TOKENS;
 
   return (
     <section className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-6 mb-6">
@@ -220,7 +223,7 @@ export default function McpAccess() {
         <form onSubmit={create} className="flex flex-wrap items-end gap-2 mb-5">
           <div className="flex-1 min-w-40">
             <label htmlFor="token-name" className="block text-xs text-gray-500 dark:text-slate-400 mb-1">
-              Name
+              Name <span className="text-gray-400 dark:text-slate-500">({live.length} of {MAX_LIVE_TOKENS} used)</span>
             </label>
             <input
               id="token-name"
@@ -259,7 +262,8 @@ export default function McpAccess() {
           </div>
           <button
             type="submit"
-            disabled={creating || !name.trim()}
+            disabled={creating || !name.trim() || atLimit}
+            title={atLimit ? `Revoke one of your ${MAX_LIVE_TOKENS} tokens to create another` : undefined}
             className="h-10 text-sm font-medium px-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-40"
           >
             {creating ? "Creating…" : "Create token"}
@@ -327,6 +331,12 @@ export default function McpAccess() {
             </li>
           ))}
         </ul>
+      )}
+
+      {revoked.length > 0 && (
+        <p className="mt-3 text-xs text-gray-400 dark:text-slate-500">
+          Revoked tokens are listed for 7 days, then removed.
+        </p>
       )}
 
       {error && <p className="mt-3 text-sm text-red-500">{error}</p>}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -171,6 +171,22 @@ export type ProgressData = {
   test_questions: Record<string, ProgressEntry>;
 };
 
+export type TokenScope = "read" | "read_write";
+
+// A personal access token, as returned by the API — metadata only, never the value.
+export type AccessToken = {
+  id: string;
+  name: string;
+  scope: TokenScope;
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+};
+
+// The create response is the one and only time the token value is available.
+export type AccessTokenCreated = AccessToken & { token: string };
+
 export type HomeData = {
   Own: Collection[];
   Following: Collection[];
@@ -258,6 +274,15 @@ export const api = {
   },
   account: {
     delete: () => request<void>("/account", { method: "DELETE" }),
+  },
+  tokens: {
+    list: () => request<AccessToken[]>("/account/tokens"),
+    create: (name: string, scope: TokenScope) =>
+      request<AccessTokenCreated>("/account/tokens", {
+        method: "POST",
+        body: JSON.stringify({ name, scope }),
+      }),
+    revoke: (id: string) => request<void>(`/account/tokens/${id}`, { method: "DELETE" }),
   },
   share: {
     generate: (collectionID: string) =>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -187,6 +187,26 @@ export type AccessToken = {
 // The create response is the one and only time the token value is available.
 export type AccessTokenCreated = AccessToken & { token: string };
 
+// An application the user connected over OAuth — what Settings lists and can disconnect.
+export type Connection = {
+  id: string;
+  client_name: string;
+  scope: TokenScope;
+  created_at: string;
+  last_used_at: string | null;
+};
+
+export type ConsentDecision = {
+  client_id: string;
+  redirect_uri: string;
+  scope: string;
+  state: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  resource: string;
+  approved: boolean;
+};
+
 export type HomeData = {
   Own: Collection[];
   Following: Collection[];
@@ -274,6 +294,13 @@ export const api = {
   },
   account: {
     delete: () => request<void>("/account", { method: "DELETE" }),
+  },
+  oauth: {
+    // Called by the consent screen; the API answers with where to send the browser next.
+    approve: (decision: ConsentDecision) =>
+      request<{ redirect_to: string }>("/oauth/approve", { method: "POST", body: JSON.stringify(decision) }),
+    connections: () => request<Connection[]>("/account/connections"),
+    disconnect: (id: string) => request<void>(`/account/connections/${id}`, { method: "DELETE" }),
   },
   tokens: {
     list: () => request<AccessToken[]>("/account/tokens"),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,7 +15,16 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
       localStorage.removeItem("logged_in");
       window.location.href = "/";
     }
-    throw new Error(`${res.status} ${res.statusText}`);
+    // Surface the server's own words when it sent any: for refusals a user can act on —
+    // "you already have 5 active tokens" — a generic message would hide the way out.
+    // Guarded: reading the body must never replace the HTTP error with a error about reading it.
+    let detail = "";
+    try {
+      detail = (await res.text()) ?? "";
+    } catch {
+      detail = "";
+    }
+    throw new Error(detail.trim() || `${res.status} ${res.statusText}`);
   }
   if (res.status === 204) return undefined as T;
   return res.json();

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,14 @@
 const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 
-async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+// Options that are ours, not fetch's.
+type RequestOpts = {
+  // Skip the global "401 → go home" handling. Needed wherever a 401 is an expected answer the
+  // page handles itself: navigating away would discard state the user cannot recreate, such as
+  // the OAuth parameters on the consent screen.
+  handle401?: boolean;
+};
+
+async function request<T>(path: string, init: RequestInit = {}, opts: RequestOpts = {}): Promise<T> {
   const isFormData = init.body instanceof FormData;
   const res = await fetch(`${BASE}${path}`, {
     ...init,
@@ -11,7 +19,7 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
     },
   });
   if (!res.ok) {
-    if (res.status === 401) {
+    if (res.status === 401 && !opts.handle401) {
       localStorage.removeItem("logged_in");
       window.location.href = "/";
     }
@@ -237,6 +245,9 @@ export async function uploadFile(file: File): Promise<string> {
 export const api = {
   auth: {
     me: () => request<{ id: string; email: string; role: string; picture: string }>("/auth/me"),
+    // Like me(), but a missing session is an answer rather than a reason to leave the page.
+    session: () =>
+      request<{ id: string; email: string; role: string; picture: string }>("/auth/me", {}, { handle401: true }),
   },
   home: {
     get: () => request<HomeData>("/home"),
@@ -307,7 +318,13 @@ export const api = {
   oauth: {
     // Called by the consent screen; the API answers with where to send the browser next.
     approve: (decision: ConsentDecision) =>
-      request<{ redirect_to: string }>("/oauth/approve", { method: "POST", body: JSON.stringify(decision) }),
+      request<{ redirect_to: string }>(
+        "/oauth/approve",
+        { method: "POST", body: JSON.stringify(decision) },
+        // A session that expired mid-flow is shown as "sign in again" on the consent screen,
+        // not as a silent bounce to the home page.
+        { handle401: true },
+      ),
     connections: () => request<Connection[]>("/account/connections"),
     disconnect: (id: string) => request<void>(`/account/connections/${id}`, { method: "DELETE" }),
   },

--- a/lib/returnTo.ts
+++ b/lib/returnTo.ts
@@ -1,0 +1,20 @@
+const KEY = "return_to";
+
+// Google's callback always lands on /auth/callback, so a page that sends the user to log in has
+// to remember where they were. Used by the OAuth consent screen: losing the authorization
+// parameters means the user has to start the connection over in the client application.
+//
+// Same-origin paths only. The value survives a redirect through an external identity provider,
+// so treating it as a URL would make it an open redirect.
+export function rememberReturnTo(pathWithQuery: string): void {
+  if (!pathWithQuery.startsWith("/") || pathWithQuery.startsWith("//")) return;
+  sessionStorage.setItem(KEY, pathWithQuery);
+}
+
+export function takeReturnTo(): string | null {
+  if (typeof window === "undefined") return null;
+  const value = sessionStorage.getItem(KEY);
+  sessionStorage.removeItem(KEY);
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}

--- a/lib/tokens.test.ts
+++ b/lib/tokens.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+
+// The token endpoints are the one place where a wrong request shape has security weight: a
+// missing `credentials: "include"` silently drops the session cookie, and a token value that
+// leaks into a URL ends up in access logs. These assert the wire contract, not the UI.
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    json: async () => body,
+  } as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("api.tokens.list", () => {
+  it("GETs /account/tokens with the session cookie", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    await api.tokens.list();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/account/tokens`);
+    expect(init.credentials).toBe("include");
+    expect(init.method).toBeUndefined();
+  });
+});
+
+describe("api.tokens.create", () => {
+  it("POSTs name and scope as JSON", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        id: "t1",
+        name: "laptop",
+        scope: "read_write",
+        created_at: "2026-08-05T00:00:00Z",
+        last_used_at: null,
+        expires_at: null,
+        revoked_at: null,
+        token: "cram_pat_secret",
+      }, 201),
+    );
+
+    const created = await api.tokens.create("laptop", "read_write");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/account/tokens`);
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("include");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ name: "laptop", scope: "read_write" });
+    // The plaintext value is only ever available from this response.
+    expect(created.token).toBe("cram_pat_secret");
+  });
+
+  it("passes a read-only scope through unchanged", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ token: "x" }, 201));
+
+    await api.tokens.create("reader", "read");
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).scope).toBe("read");
+  });
+});
+
+describe("api.tokens.revoke", () => {
+  it("DELETEs by id and keeps the id out of the query string", async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 204, statusText: "" } as Response);
+
+    await api.tokens.revoke("t1");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/account/tokens/t1`);
+    expect(url).not.toContain("?");
+    expect(init.method).toBe("DELETE");
+    expect(init.credentials).toBe("include");
+  });
+
+  it("resolves without parsing a body on 204", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: "",
+      json: async () => {
+        throw new Error("204 has no body to parse");
+      },
+    } as unknown as Response);
+
+    await expect(api.tokens.revoke("t1")).resolves.toBeUndefined();
+  });
+});
+
+describe("failure handling", () => {
+  it("throws on a 4xx so callers can surface an error", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: "bad scope" }, 400));
+
+    await expect(api.tokens.create("x", "read")).rejects.toThrow(/400/);
+  });
+});

--- a/lib/tokens.test.ts
+++ b/lib/tokens.test.ts
@@ -13,6 +13,8 @@ function jsonResponse(body: unknown, status = 200) {
     status,
     statusText: "",
     json: async () => body,
+    // A real Response always has text(); the client reads it to surface server-side refusals.
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
   } as Response;
 }
 
@@ -105,8 +107,18 @@ describe("api.tokens.revoke", () => {
 
 describe("failure handling", () => {
   it("throws on a 4xx so callers can surface an error", async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ error: "bad scope" }, 400));
+    fetchMock.mockResolvedValue({ ok: false, status: 400, statusText: "Bad Request" } as Response);
 
     await expect(api.tokens.create("x", "read")).rejects.toThrow(/400/);
+  });
+
+  it("carries the server's message, which is the part a user can act on", async () => {
+    // The token limit is refused with a sentence that names the way out; a generic
+    // "could not create" would hide it.
+    fetchMock.mockResolvedValue(
+      jsonResponse("you already have 5 active tokens; revoke one before creating another", 409),
+    );
+
+    await expect(api.tokens.create("x", "read")).rejects.toThrow(/revoke one before creating another/);
   });
 });


### PR DESCRIPTION
The user-facing half of the MCP work (treant-dev/cram-back#22). Nothing here works until that is merged.

## MCP access, in Settings

Create, list and revoke personal access tokens — and, while the value is on screen, which is the only time it exists, the exact snippet needed to connect.

Two clients, deliberately not shown as equals. **Claude Code** gets the plain `claude mcp add` command: the token goes from its config straight to our API. **Claude Desktop** is behind a disclosure, because its connectors speak only OAuth, so that route runs `mcp-remote` — an open-source bridge — with the token passed to it as an environment variable. That trade-off is stated in the UI rather than buried in docs, and it disappears once OAuth is the normal path.

The form shows how many of the five token slots are used and disables the button at the limit, but the server still decides; this is a hint, not the rule.

## Consent screen

`/oauth/consent` states what the scope actually allows in concrete terms, which account is being connected, and **the host the browser will be sent to** — the one fact that distinguishes a real client from a lookalike, since the name is self-declared by the client.

Settings gains a list of connected applications with Disconnect. An approval the user cannot see or take back is worse than no approval flow at all.

## The fix worth reading

The consent screen originally checked the session only when Approve was pressed. Our API client turns a 401 into "go to the home page", so a signed-out visitor was bounced out of the flow along with the authorization parameters — the only way back was to start over inside the client application.

It now checks first and offers to sign in, returning to the same URL afterwards. Google's callback always lands on `/auth/callback`, so the destination is parked in `sessionStorage`; it is stored and read as a same-origin path, because a value that survives a redirect through an identity provider would otherwise be an open redirect.

That fix needed a second one: the session probe itself would have triggered the same redirect. `/auth/me` and `/oauth/approve` now opt out of the global 401 handling, so a session that lapses mid-flow becomes a sign-in prompt instead of a silent exit.

## Also

The API client throws the server's message instead of `400 Bad Request`. It matters here specifically: "you already have 5 active tokens; revoke one before creating another" tells the user what to do, and a generic failure hides it.

## Testing

`vitest` green (37). `lib/tokens.test.ts` covers the request shapes where a mistake has security weight: `credentials: "include"` present, the token id never in a query string, 204 not parsed as JSON, and the server's message surfacing.

No Playwright spec yet for the token flow or the consent screen — worth adding, since the project has the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)