### PR TITLE
Card hints, a typing mode, search and paging

### DIFF
--- a/app/collections/[id]/blitz/page.tsx
+++ b/app/collections/[id]/blitz/page.tsx
@@ -2,24 +2,67 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { api } from "@/lib/api";
+import { api, type Exercise } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
 import { fromBlitz, type SessionItem } from "@/lib/session";
+import Navbar from "@/components/Navbar";
 import StudySession from "@/components/StudySession";
+import ExerciseWorksheet from "@/components/ExerciseWorksheet";
+
+// An exercise counts as answered once any part of it has a saved result: a quiz by its own
+// id, a bank/choice worksheet by any of its sentences. Partly-finished worksheets are left
+// out too — blitz is for material not started, and finishing one belongs in the editor's
+// reset, not in a session that would reopen it every time.
+function unanswered(exercises: Exercise[], saved: Record<string, unknown>): Exercise[] {
+  return exercises.filter((ex) =>
+    ex.Kind === "quiz" ? !saved[ex.ID] : !ex.Sentences.some((s) => saved[s.id])
+  );
+}
 
 export default function BlitzPage(props: PageProps<"/collections/[id]/blitz">) {
   const router = useRouter();
   const [items, setItems] = useState<SessionItem[]>([]);
   const [collectionID, setCollectionID] = useState("");
+  const [pending, setPending] = useState<Exercise[]>([]);
+  const [savedResults, setSavedResults] = useState<Record<string, string[]>>({});
+  // Exercises run first and are done with once worked through; cards follow.
+  const [phase, setPhase] = useState<"exercises" | "cards">("exercises");
   const [error, setError] = useState<string | undefined>();
 
   useEffect(() => {
     if (!isLoggedIn()) { router.replace("/"); return; }
     props.params.then(({ id }) => {
       setCollectionID(id);
-      return api.blitz.get(id);
-    }).then((result) => setItems(fromBlitz(result))).catch(() => setError("Failed to load blitz"));
+      return Promise.all([
+        api.blitz.get(id),
+        api.collections.get(id),
+        api.exercises.getResults(id).catch(() => ({})),
+      ]);
+    }).then(([blitz, col, results]) => {
+      setItems(fromBlitz(blitz));
+      const submitted: Record<string, string[]> = {};
+      for (const [sid, e] of Object.entries(results)) submitted[sid] = e.submitted;
+      setSavedResults(submitted);
+      setPending(unanswered(col.Exercises ?? [], results));
+    }).catch(() => setError("Failed to load blitz"));
   }, [router, props.params]);
+
+  if (phase === "exercises" && pending.length > 0) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <main className="max-w-3xl mx-auto w-full px-4 py-8 flex-1">
+          <ExerciseWorksheet
+            exercises={pending}
+            collectionID={collectionID}
+            saved={savedResults}
+            single
+            onDone={() => setPhase("cards")}
+          />
+        </main>
+      </div>
+    );
+  }
 
   return <StudySession items={items} collectionID={collectionID} doneTitle="Blitz complete!" error={error} requeueWrongCards />;
 }

--- a/app/collections/[id]/cards/page.tsx
+++ b/app/collections/[id]/cards/page.tsx
@@ -95,15 +95,18 @@ export default function CardsPage(props: PageProps<"/collections/[id]/cards">) {
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
-      <main className="flex-1 flex flex-col items-center justify-center px-4 gap-3">
-        <div className="relative w-full max-w-lg flex items-center justify-end">
+      {/* Three rows with equal 1fr above and below pin the card itself to the middle of the
+          screen: the hint appearing underneath grows into the bottom row instead of pushing
+          the card up, so flipping never moves it. */}
+      <main className="flex-1 grid grid-rows-[1fr_auto_1fr] px-4">
+        <div className="self-end mx-auto mb-3 relative w-full max-w-lg flex items-center justify-end">
           <p className="absolute left-1/2 -translate-x-1/2 text-xs text-gray-400 dark:text-slate-500 uppercase tracking-wide">{flipped ? "Back" : "Front"}</p>
           <p className="text-sm text-gray-400 dark:text-slate-500">{index + 1} / {cards.length}</p>
         </div>
 
         <div
           onClick={flip}
-          className="relative cursor-pointer w-full max-w-lg min-h-48 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-sm flex flex-col items-center justify-center p-8 text-center select-none hover:shadow-md dark:hover:border-slate-600 transition-all gap-4"
+          className="relative cursor-pointer mx-auto w-full max-w-lg min-h-48 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-sm flex flex-col items-center justify-center p-8 text-center select-none hover:shadow-md dark:hover:border-slate-600 transition-all gap-4"
         >
           <SpeakButton text={card.Term} className="absolute top-3 right-3" />
           {card.Image && !flipped && (
@@ -114,14 +117,28 @@ export default function CardsPage(props: PageProps<"/collections/[id]/cards">) {
           </p>
         </div>
 
-        <div className="w-full max-w-lg flex items-center justify-between">
-          <p className="text-xs text-gray-400 dark:text-slate-500">Space to flip · Enter for next</p>
-          <button
-            onClick={next}
-            className="bg-indigo-600 text-white px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
-          >
-            {index + 1 >= cards.length ? "Finish" : "Next →"}
-          </button>
+        <div className="self-start mx-auto mt-3 w-full max-w-lg flex flex-col gap-3">
+          {/* A card of its own under the back side: the hint is about the card, not part of the
+              answer, and sharing one box made it read as a footnote to the definition. No reveal
+              button here — flipping already gave the answer away. */}
+          {flipped && card.Hint && (
+            <div
+              data-testid="hint-card"
+              className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-sm px-6 py-4 text-center"
+            >
+              <p className="text-sm text-gray-500 dark:text-slate-400">{card.Hint}</p>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-gray-400 dark:text-slate-500">Space to flip · Enter for next</p>
+            <button
+              onClick={next}
+              className="bg-indigo-600 text-white px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+            >
+              {index + 1 >= cards.length ? "Finish" : "Next →"}
+            </button>
+          </div>
         </div>
       </main>
     </div>

--- a/app/collections/[id]/match/page.tsx
+++ b/app/collections/[id]/match/page.tsx
@@ -67,6 +67,13 @@ export default function MatchPage(props: PageProps<"/collections/[id]/match">) {
     if (a.cardId === b.cardId) {
       setMatched((prev) => new Set([...prev, a.id, b.id]));
       setFlipped([]);
+      // A completed pair counts as a correct answer for that card, like any other mode.
+      // Mismatches are not reported: turning over the wrong tile is how a memory board is
+      // explored, and a wrong answer halves the level. Repeat runs cannot inflate anything
+      // either — the server ignores a correct answer given before the card is due.
+      if (isLoggedIn() && collectionID) {
+        api.progress.update(collectionID, "card", a.cardId, true, 0).catch(() => {});
+      }
     } else {
       setLock(true);
       setWrong(new Set([a.id, b.id]));

--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { api, Collection, Card, TestQuestion, TestAnswer, Exercise, ProgressEntry, DraftDiffEntry } from "@/lib/api";
 import LevelDot from "@/components/LevelDot";
 import { isLoggedIn } from "@/lib/auth";
+import { fuzzyBest } from "@/lib/fuzzy";
 import Navbar from "@/components/Navbar";
 import ImageUpload from "@/components/ImageUpload";
 import { ExerciseBody } from "@/components/ExerciseWorksheet";
@@ -17,12 +18,15 @@ const inputCls = "border border-gray-300 dark:border-slate-600 bg-white dark:bg-
 const formCls = "bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-4 mb-3 flex flex-col gap-3";
 const btnBase = "text-sm px-3 py-1.5 rounded-lg border transition-colors disabled:opacity-60 font-medium";
 
+// Items per page in view mode. Long enough that most collections stay on one page.
+const PAGE_SIZE = 20;
+
 
 // Reconstruct the published DTO of a staged-for-deletion item, so deleted rows
 // render with the same markup as normal rows (just tinted red).
 function cardFromEntry(e: DraftDiffEntry): Card {
-  const c = (e.Before?.Content ?? {}) as { term?: string; definition?: string; image?: string };
-  return { ID: e.ItemID, CollectionID: "", Term: c.term ?? "", Definition: c.definition ?? "", Image: c.image ?? "", Position: 0, CreatedAt: "", UpdatedAt: "" };
+  const c = (e.Before?.Content ?? {}) as { term?: string; definition?: string; image?: string; hint?: string };
+  return { ID: e.ItemID, CollectionID: "", Term: c.term ?? "", Definition: c.definition ?? "", Hint: c.hint ?? "", Image: c.image ?? "", Position: 0, CreatedAt: "", UpdatedAt: "" };
 }
 function quizFromEntry(e: DraftDiffEntry): TestQuestion {
   const c = (e.Before?.Content ?? {}) as { question?: string; options?: TestAnswer[] };
@@ -62,54 +66,13 @@ function IconBtn({ emoji, title, onClick, danger, type = "button", form, disable
   );
 }
 
-// Mini-games playable over a collection's cards. Add new ones here — they show up
-// in the 🎮 menu and in the 🎲 Random pick automatically.
+// Mini-games playable over a collection's cards. Add one here and it becomes a button
+// next to Blitz — each game names itself rather than hiding behind a 🎮 menu.
 const MINI_GAMES: { emoji: string; label: string; slug: string }[] = [
   { emoji: "🃏", label: "Match", slug: "match" },
   { emoji: "🔗", label: "Connect", slug: "connect" },
+  { emoji: "⌨️", label: "Type", slug: "type" },
 ];
-
-// 🎮 menu next to Blitz: pick a mini-game (🎲 Random first). Disabled when the
-// collection has too few cards to play.
-function GamesMenu({ collectionID, disabled }: { collectionID: string; disabled?: boolean }) {
-  const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!open) return;
-    function onDoc(e: MouseEvent) { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); }
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, [open]);
-
-  const go = (slug: string) => { setOpen(false); router.push(`/collections/${collectionID}/${slug}`); };
-  const random = () => go(MINI_GAMES[Math.floor(Math.random() * MINI_GAMES.length)].slug);
-  const itemCls = "w-full text-left px-3 py-1.5 text-sm text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-800";
-
-  if (disabled) {
-    return <span title="Needs at least 5 cards" className="px-4 py-2 rounded-lg text-sm border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-400 dark:text-slate-600 cursor-not-allowed">🎮</span>;
-  }
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        onClick={() => setOpen((o) => !o)}
-        title="Mini games"
-        aria-label="Mini games"
-        className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
-      >
-        🎮
-      </button>
-      {open && (
-        <div className="absolute z-20 mt-1 left-0 min-w-[10rem] rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg py-1">
-          <button onClick={random} className={itemCls}>🎲 Random</button>
-          {MINI_GAMES.map((g) => (
-            <button key={g.slug} onClick={() => go(g.slug)} className={itemCls}>{g.emoji} {g.label}</button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
 
 // Form fields box (used inside CardForm/TestForm; Save/Cancel live in a side panel).
 const formBox = "bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl p-4 flex flex-col gap-3 flex-1 min-w-0";
@@ -377,7 +340,7 @@ function AddItemModal({ collectionID, userRole, draft, onClose, onCardSave, onQu
   userRole?: string | null;
   draft?: boolean; // stage into the draft (edit) vs write live (view quick-add)
   onClose: () => void;
-  onCardSave: (term: string, definition: string, image: string) => void;
+  onCardSave: (term: string, definition: string, image: string, hint: string) => void;
   onQuizSave: (question: string, options: TestAnswer[], image: string) => void;
   onImported: () => void;
 }) {
@@ -414,7 +377,7 @@ function AddItemModal({ collectionID, userRole, draft, onClose, onCardSave, onQu
           ))}
         </div>
       ) : type === "card" ? (
-        <CardForm formId={FORM_ID} hideActions onSave={(t, d, i) => { onCardSave(t, d, i); onClose(); }} onCancel={() => setType(null)} userRole={userRole} />
+        <CardForm formId={FORM_ID} hideActions onSave={(t, d, i, h) => { onCardSave(t, d, i, h); onClose(); }} onCancel={() => setType(null)} userRole={userRole} />
       ) : type === "quiz" ? (
         <TestForm formId={FORM_ID} hideActions onSave={(q, o, i) => { onQuizSave(q, o, i); onClose(); }} onCancel={() => setType(null)} />
       ) : (
@@ -428,7 +391,7 @@ function AddItemModal({ collectionID, userRole, draft, onClose, onCardSave, onQu
 
 function CardForm({ initial, onSave, onCancel, userRole, formId, hideActions }: {
   initial?: Card;
-  onSave: (term: string, definition: string, image: string) => void;
+  onSave: (term: string, definition: string, image: string, hint: string) => void;
   onCancel: () => void;
   userRole?: string | null;
   formId?: string;      // lets an external Save button (modal header) submit this form
@@ -436,6 +399,7 @@ function CardForm({ initial, onSave, onCancel, userRole, formId, hideActions }: 
 }) {
   const [term, setTerm] = useState(initial?.Term ?? "");
   const [definition, setDefinition] = useState(initial?.Definition ?? "");
+  const [hint, setHint] = useState(initial?.Hint ?? "");
   const [image, setImage] = useState(initial?.Image ?? "");
   const [suggesting, setSuggesting] = useState(false);
   const canSuggest = userRole === "admin" || userRole === "pro";
@@ -456,7 +420,7 @@ function CardForm({ initial, onSave, onCancel, userRole, formId, hideActions }: 
   function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!term.trim() || !definition.trim()) return;
-    onSave(term.trim(), definition.trim(), image);
+    onSave(term.trim(), definition.trim(), image, hint.trim());
   }
 
   return (
@@ -472,6 +436,8 @@ function CardForm({ initial, onSave, onCancel, userRole, formId, hideActions }: 
             </button>
           )}
         </div>
+        {/* Optional: revealed on request while studying, so it must not restate the definition. */}
+        <input className={inputCls} placeholder="Hint (optional)" value={hint} onChange={(e) => setHint(e.target.value)} maxLength={2000} />
         <ImageUpload value={image} onChange={setImage} />
       </div>
       {!hideActions && (
@@ -606,6 +572,8 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
   const [isFollowed, setIsFollowed] = useState(false);
   const [followLoading, setFollowLoading] = useState(false);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set()); // view mode: cards/quiz whose answer is revealed
+  const [search, setSearch] = useState(""); // view mode: fuzzy filter over the item list
+  const [page, setPage] = useState(1);      // view mode: 1-based page of the item list
 
   function toggleExpand(id: string) {
     setExpandedIds((prev) => {
@@ -799,9 +767,10 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
 
   // ── Granular draft operations (edit mode) — each stages into item_draft ───────
 
-  const cardBody = (term: string, definition: string, image: string) => ({
+  const cardBody = (term: string, definition: string, image: string, hint: string) => ({
     type: "card",
-    content: { term, definition, ...(image ? { image } : {}) },
+    // image and hint are written only when set, so a card without them keeps the shape it had.
+    content: { term, definition, ...(image ? { image } : {}), ...(hint ? { hint } : {}) },
   });
   const quizBody = (question: string, options: TestAnswer[], image: string) => ({
     type: "exercise",
@@ -813,15 +782,15 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
     },
   });
 
-  async function addCard(term: string, definition: string, image: string) {
+  async function addCard(term: string, definition: string, image: string, hint: string) {
     if (!collection) return;
-    await api.drafts.addItem(collection.ID, cardBody(term, definition, image));
+    await api.drafts.addItem(collection.ID, cardBody(term, definition, image, hint));
     await refreshDraft(collection.ID);
     closeAllForms();
   }
-  async function updateCard(term: string, definition: string, image: string) {
+  async function updateCard(term: string, definition: string, image: string, hint: string) {
     if (!collection || !editingCard) return;
-    await api.drafts.updateItem(collection.ID, editingCard.ID, cardBody(term, definition, image));
+    await api.drafts.updateItem(collection.ID, editingCard.ID, cardBody(term, definition, image, hint));
     await refreshDraft(collection.ID);
     setEditingCard(null);
   }
@@ -879,9 +848,9 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
   // ── Immediate actions (view mode, owner only) ────────────────────────────────
 
   // Quick-add: write a single item straight to the published collection (no draft).
-  async function quickAddCard(term: string, definition: string, image: string) {
+  async function quickAddCard(term: string, definition: string, image: string, hint: string) {
     if (!collection) return;
-    await api.cards.add(collection.ID, term, definition, image, (collection.Cards ?? []).length);
+    await api.cards.add(collection.ID, term, definition, image, hint, (collection.Cards ?? []).length);
     setCollection(await api.collections.get(collection.ID));
   }
 
@@ -1030,24 +999,47 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
         ...quizzes.map((q) => ({ kind: "quiz" as const, id: q.ID, del: false, quiz: q })),
         ...exercises.map((x) => ({ kind: "exercise" as const, id: x.ID, del: false, ex: x })),
       ].sort((a, b) => cmpRank(a.id, b.id));
+  // Everything a search should look at, per item — the answer side included, since a user
+  // hunting for "the card about mutexes" may only remember the definition.
+  const searchable = (entry: (typeof listItems)[number]): string[] =>
+    entry.kind === "card"
+      ? [entry.card.Term, entry.card.Definition, entry.card.Hint]
+      : entry.kind === "quiz"
+      ? [entry.quiz.Question, ...entry.quiz.Options.map((o) => o.text)]
+      : entry.ex.Kind === "quiz"
+      ? [entry.ex.Title, entry.ex.Question, ...entry.ex.Options.map((o) => o.text)]
+      : [entry.ex.Title, ...entry.ex.Sentences.map((sn) => sn.text)];
+
+  // Fuzzy filter, best matches first. Edit mode is deliberately excluded: a reorder computes
+  // the new rank from an item's neighbours in the rendered list, so a filtered list would
+  // hand it the wrong ones.
+  const query = search.trim();
+  const visibleItems = editMode || query === ""
+    ? listItems
+    : listItems
+        .map((entry, i) => ({ entry, i, score: fuzzyBest(query, searchable(entry)) }))
+        .filter((r): r is { entry: (typeof listItems)[number]; i: number; score: number } => r.score !== null)
+        .sort((a, b) => b.score - a.score || a.i - b.i)
+        .map((r) => r.entry);
+
+  // Pages come after the search, so a query still sees the whole collection and only its
+  // results are sliced. Edit mode is unpaged for the same reason it is unfiltered.
+  const pageCount = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE));
+  // Clamped rather than stored: the list shrinks as a query narrows, and a page number left
+  // pointing past the end would render nothing.
+  const currentPage = Math.min(page, pageCount);
+  const pagedItems = editMode ? visibleItems : visibleItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
   // View mode: cards & quiz collapse to their prompt; expand reveals the answer.
-  const collapsibleIds = editMode ? [] : listItems.filter((e) => e.kind === "card" || e.kind === "quiz").map((e) => e.id);
+  const collapsibleIds = editMode ? [] : pagedItems.filter((e) => e.kind === "card" || e.kind === "quiz").map((e) => e.id);
   const allExpanded = collapsibleIds.length > 0 && collapsibleIds.every((id) => expandedIds.has(id));
   // Mixed collections: capability by content presence, not a single collection type.
-  const hasExercises = allExercises.length > 0;
   const itemCount = cards.length + allExercises.length;
   const hasFlip = cards.length >= 2;               // flip-card mode needs ≥2 cards
   const hasBlitz = cards.length >= 1;              // blitz is cards-only
   const hasMatch = cards.length >= 5;              // matching mini-game needs ≥5 pairs
   const allItemKeys = cards.map((c) => `card:${c.ID}`); // progress is card-only
   const allMastered = allItemKeys.length > 0 && allItemKeys.every((k) => itemProgress[k]?.level === 7);
-  const now = new Date();
-  const dueCount = allItemKeys.filter((k) => {
-    const p = itemProgress[k];
-    if (!p) return true; // never seen — due (matches backend GetBlitz)
-    if (p.level === 7) return false; // mastered — not due
-    return !p.next_review_at || new Date(p.next_review_at) <= now;
-  }).length;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -1113,17 +1105,27 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
                 <span className="bg-indigo-300 dark:bg-indigo-900 text-white px-4 py-2 rounded-lg text-sm font-medium cursor-not-allowed opacity-60">Blitz</span>
               ) : (
                 <Link href={`/collections/${collection.ID}/blitz`} className="bg-indigo-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors">
-                  Blitz{dueCount > 0 && ` (${dueCount})`}
+                  Blitz
                 </Link>
               )
             )}
-            {cards.length >= 1 && <GamesMenu collectionID={collection.ID} disabled={!hasMatch} />}
+            {cards.length >= 1 && MINI_GAMES.map((g) => (
+              hasMatch ? (
+                <Link key={g.slug} href={`/collections/${collection.ID}/${g.slug}`} title={g.label} aria-label={g.label} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">
+                  {g.emoji}
+                </Link>
+              ) : (
+                <span key={g.slug} title={`${g.label} needs at least 5 cards`} aria-label={g.label} className="px-4 py-2 rounded-lg text-sm font-medium border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 opacity-40 cursor-not-allowed">
+                  {g.emoji}
+                </span>
+              )
+            ))}
             {hasFlip && (
               <Link href={`/collections/${collection.ID}/cards`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Cards</Link>
             )}
-            {hasExercises && (
-              <Link href={`/collections/${collection.ID}/exercises`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Exercise</Link>
-            )}
+            {/* No Exercise button: unanswered exercises open at the start of Blitz. Redoing an
+                answered one goes through the editor's reset, which is what clears the saved
+                answers blitz reads. */}
             {currentUserID !== null && !isOwner && (
               <button
                 onClick={toggleFollow}
@@ -1188,10 +1190,40 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
           />
         )}
 
+        {/* Search: view mode only, and only once the list is long enough to be worth hunting
+            through. Filtering is local — the whole collection is already in memory. */}
+        {!editMode && listItems.length >= 5 && (
+          <div className="relative mb-4">
+            {/* Decorative: the placeholder already says what the field is, so the glass is
+                hidden from screen readers and does not swallow clicks aimed at the input. */}
+            <span aria-hidden className="absolute left-3 top-1/2 -translate-y-1/2 text-sm pointer-events-none select-none">🔍</span>
+            <input
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+              placeholder="Search…"
+              aria-label="Search items"
+              data-testid="item-search"
+              className={inputCls + " w-full pl-9 pr-9"}
+            />
+            {search && (
+              <button
+                onClick={() => { setSearch(""); setPage(1); }}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 text-sm px-1"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        )}
+        {!editMode && query !== "" && visibleItems.length === 0 && (
+          <p className="text-sm text-gray-400 dark:text-slate-500 mb-8">Nothing matches “{query}”.</p>
+        )}
+
         {/* ── Unified item list (edit + view) ── */}
-        {(listItems.length > 0 || editMode) && (
+        {(pagedItems.length > 0 || editMode) && (
           <ul className="flex flex-col gap-3 mb-8">
-            {listItems.map((entry) => {
+            {pagedItems.map((entry) => {
               if (editMode && entry.kind === "card" && !entry.del && editingCard?.ID === entry.id) {
                 return <li key={entry.id}><CardForm initial={entry.card} onSave={updateCard} onCancel={() => setEditingCard(null)} userRole={currentUserRole} /></li>;
               }
@@ -1247,7 +1279,12 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
                     <div className="text-gray-900 dark:text-slate-100">{entry.card.Term}</div>
                     {/* animated reveal: grid rows 0fr → 1fr */}
                     <div className={`grid transition-[grid-template-rows] duration-200 ease-out ${showAnswer ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}>
-                      <div className="overflow-hidden"><div className="text-gray-600 dark:text-slate-400 text-sm mt-1">{entry.card.Definition}</div></div>
+                      <div className="overflow-hidden">
+                        <div className="text-gray-600 dark:text-slate-400 text-sm mt-1">{entry.card.Definition}</div>
+                        {/* The hint rides along with the answer here — this list is for reviewing
+                            and editing content, not for testing yourself on it. */}
+                        {entry.card.Hint && <div className="text-gray-400 dark:text-slate-500 text-xs mt-1">{entry.card.Hint}</div>}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1304,6 +1341,27 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
             })}
             {editMode && listItems.length === 0 && <p className="text-sm text-gray-400 dark:text-slate-500">No items yet — use “Add item” or “Import”.</p>}
           </ul>
+        )}
+
+        {/* Pager: only when there is a second page to go to. */}
+        {!editMode && pageCount > 1 && (
+          <div className="flex items-center justify-center gap-3 mb-8">
+            <button
+              onClick={() => setPage(currentPage - 1)}
+              disabled={currentPage === 1}
+              className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700`}
+            >
+              ←
+            </button>
+            <span data-testid="page-indicator" className="text-sm text-gray-500 dark:text-slate-400">{currentPage} / {pageCount}</span>
+            <button
+              onClick={() => setPage(currentPage + 1)}
+              disabled={currentPage === pageCount}
+              className={`${btnBase} border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700`}
+            >
+              →
+            </button>
+          </div>
         )}
 
         {/* ── Owner actions (view mode only) ── */}

--- a/app/collections/[id]/type/page.tsx
+++ b/app/collections/[id]/type/page.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { api, Card } from "@/lib/api";
+import { isLoggedIn } from "@/lib/auth";
+import Navbar from "@/components/Navbar";
+import { isTypedCorrect } from "@/lib/typing";
+
+const SESSION_SIZE = 7; // cards per round, matching blitz
+
+// Typing mini-game: the definition is shown, the learner writes the term from memory. The
+// strictest of the card modes — nothing to recognise, so a right answer means real recall,
+// and both outcomes are reported as progress the way blitz and connect do.
+export default function TypePage(props: PageProps<"/collections/[id]/type">) {
+  const router = useRouter();
+  const [collectionID, setCollectionID] = useState("");
+  const [cards, setCards] = useState<Card[]>([]);
+  const [index, setIndex] = useState(0);
+  const [typed, setTyped] = useState("");
+  const [verdict, setVerdict] = useState<"right" | "wrong" | null>(null);
+  const [score, setScore] = useState(0);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Per card, as in blitz: the first press unlocks the hint, and it is on screen only while
+  // asked for. Asking costs nothing — the term still has to be typed.
+  const [hintUnlocked, setHintUnlocked] = useState(false);
+  const [hintVisible, setHintVisible] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    props.params.then(({ id }) => {
+      setCollectionID(id);
+      return isLoggedIn() ? api.collections.get(id) : api.collections.getPublic(id);
+    }).then((col) => {
+      const arr = [...(col.Cards ?? [])].filter((c) => c.Term.trim() && c.Definition.trim());
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      // Same session length as blitz: writing a term from memory is the slowest of the
+      // modes, and a deck of thirty would turn one round into a chore.
+      setCards(arr.slice(0, SESSION_SIZE));
+    }).catch(() => setError("Failed to load cards"));
+  }, [props.params]);
+
+  useEffect(() => {
+    if (!done || !collectionID) return;
+    const t = setTimeout(() => router.replace(`/collections/${collectionID}`), 1700);
+    return () => clearTimeout(t);
+  }, [done, collectionID, router]);
+
+  const card = cards[index];
+
+  // Keep the caret in the box between cards — this mode is played entirely from the keyboard.
+  useEffect(() => { inputRef.current?.focus(); }, [index, verdict]);
+
+  const check = useCallback(() => {
+    if (!card || verdict !== null || typed.trim() === "") return;
+    const right = isTypedCorrect(typed, card.Term);
+    setVerdict(right ? "right" : "wrong");
+    if (right) setScore((s) => s + 1);
+    if (isLoggedIn() && collectionID) {
+      // Unlike match, a wrong answer here is a real failure of recall, not the cost of
+      // exploring a board, so it is reported as one.
+      api.progress.update(collectionID, "card", card.ID, right, 0).catch(() => {});
+    }
+  }, [card, typed, verdict, collectionID]);
+
+  const next = useCallback(() => {
+    setVerdict(null);
+    setTyped("");
+    setHintUnlocked(false);
+    setHintVisible(false);
+    if (index + 1 >= cards.length) { setDone(true); return; }
+    setIndex((i) => i + 1);
+  }, [index, cards.length]);
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-4">
+          <p className="text-red-500">{error}</p>
+          <button onClick={() => window.history.back()} className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline">Go back</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (done) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-4">
+          <h2 className="text-2xl font-bold">Round complete!</h2>
+          <p className="text-gray-500 dark:text-slate-400 text-lg">{score} / {cards.length} correct</p>
+          <p className="text-gray-400 dark:text-slate-500 text-sm">Returning to collection…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!card) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <main className="flex-1 flex flex-col items-center justify-center px-4 gap-3 animate-pulse">
+          <div className="w-full max-w-lg h-4 bg-gray-200 dark:bg-slate-800 rounded" />
+          <div className="w-full max-w-lg min-h-48 bg-gray-100 dark:bg-slate-800 rounded-2xl" />
+          <div className="w-full max-w-lg h-10 bg-gray-100 dark:bg-slate-800 rounded-lg" />
+        </main>
+      </div>
+    );
+  }
+
+  const inputTint =
+    verdict === "right" ? "border-green-400 dark:border-green-600 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300"
+    : verdict === "wrong" ? "border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300"
+    : "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100";
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      {/* Same three-row grid as the flashcards: the prompt stays put whether or not a verdict
+          and a hint are showing underneath. */}
+      <main className="flex-1 grid grid-rows-[1fr_auto_1fr] px-4">
+        <div className="self-end mx-auto mb-3 w-full max-w-lg flex items-center justify-between">
+          <p className="text-xs text-gray-400 dark:text-slate-500 uppercase tracking-wide">Write the term</p>
+          <p className="text-sm text-gray-400 dark:text-slate-500">{index + 1} / {cards.length}</p>
+        </div>
+
+        <div className="mx-auto w-full max-w-lg min-h-48 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-sm flex flex-col items-center justify-center p-8 text-center gap-4">
+          <p className="text-xl font-medium text-gray-900 dark:text-slate-100">{card.Definition}</p>
+        </div>
+
+        <div className="self-start mx-auto mt-3 w-full max-w-lg flex flex-col gap-3">
+          <div className="relative">
+            {/* Decorative, like the collection search's glass: the label already names the
+                field, and the icon must not eat clicks meant for the input. */}
+            <span aria-hidden className="absolute left-4 top-1/2 -translate-y-1/2 text-lg pointer-events-none select-none">⌨️</span>
+          <input
+            ref={inputRef}
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); verdict === null ? check() : next(); } }}
+            readOnly={verdict !== null}
+            placeholder="Type the term…"
+            aria-label="Type the term"
+            data-testid="type-input"
+            autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            // Left-aligned throughout: the caret starts at the placeholder's first letter and
+            // stays where the typing left it. Centring only the typed text would shift every
+            // character already written on each new keystroke.
+            // No focus ring: the field is focused the whole time in this mode, so a permanent
+            // blue halo says nothing and fights the green/red verdict tint for attention.
+            className={`w-full rounded-xl border pl-12 pr-4 py-3 text-left text-lg focus:outline-none placeholder:text-gray-400 dark:placeholder:text-slate-500 ${inputTint}`}
+          />
+          </div>
+
+          {/* Only shown after a wrong answer: seeing the right spelling is the whole lesson. */}
+          {verdict === "wrong" && (
+            <p data-testid="type-answer" className="text-center text-sm text-gray-600 dark:text-slate-300">
+              Correct answer: <span className="font-medium">{card.Term}</span>
+            </p>
+          )}
+
+          <div className="flex items-center justify-between">
+            {/* Offered, never pushed — the same bulb as blitz. No keyboard shortcut here: every
+                letter belongs to the answer being typed. */}
+            {card.Hint ? (
+              <div className="relative">
+                <button
+                  type="button"
+                  data-testid="hint-button"
+                  onClick={() => { setHintUnlocked(true); setHintVisible(true); }}
+                  onMouseEnter={() => hintUnlocked && setHintVisible(true)}
+                  onMouseLeave={() => setHintVisible(false)}
+                  onBlur={() => setHintVisible(false)}
+                  onTouchStart={(e) => { e.preventDefault(); setHintUnlocked(true); setHintVisible(true); }}
+                  onTouchEnd={() => setHintVisible(false)}
+                  onTouchCancel={() => setHintVisible(false)}
+                  onContextMenu={(e) => e.preventDefault()}
+                  aria-label="Show hint"
+                  className={`select-none text-base leading-none w-9 h-9 rounded-lg border transition-colors ${
+                    hintVisible
+                      ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+                      : "border-gray-300 dark:border-slate-600 hover:border-amber-300 dark:hover:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20"
+                  }`}
+                >
+                  💡
+                </button>
+                {hintVisible && (
+                  <div
+                    role="tooltip"
+                    data-testid="hint-text"
+                    className="absolute top-0 left-full ml-2 z-10 w-72 max-w-[80vw] rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg px-4 py-3 text-left text-sm text-gray-600 dark:text-slate-300"
+                  >
+                    {card.Hint}
+                  </div>
+                )}
+              </div>
+            ) : <span />}
+            {verdict === null ? (
+              <button
+                onClick={check}
+                disabled={typed.trim() === ""}
+                className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 disabled:opacity-40 transition-colors"
+              >
+                Check
+              </button>
+            ) : (
+              <button onClick={next} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 transition-colors">
+                {index + 1 >= cards.length ? "Finish" : "Next →"}
+              </button>
+            )}
+          </div>
+
+          <p className="-mt-1 text-xs text-center text-gray-400 dark:text-slate-500">
+            Enter to {verdict === null ? "check" : "continue"}
+          </p>
+        </div>
+      </main>
+
+      <div className="flex justify-center pb-10">
+        <Link
+          href={collectionID ? `/collections/${collectionID}` : "/collections"}
+          className="inline-flex items-center gap-1 text-sm font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+        >
+          ← Back
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/StudySession.tsx
+++ b/components/StudySession.tsx
@@ -8,7 +8,12 @@ import SpeakButton from "@/components/SpeakButton";
 import LevelDot from "@/components/LevelDot";
 import { api, type ProgressEntry } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
+import { isTypedCorrect } from "@/lib/typing";
 import type { SessionItem } from "@/lib/session";
+
+// From this level on, a card is asked to be written rather than picked: recognising one of
+// four options stops proving anything once the answer is this well known.
+const TYPE_FROM_LEVEL = 5;
 
 type Props = {
   items: SessionItem[];
@@ -75,6 +80,12 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   const [isCorrect, setIsCorrect] = useState(false);
   const [score, setScore] = useState(0);
   const [done, setDone] = useState(false);
+  // Per item: unlocked by the first press, then shown only while asked for (hover or hold).
+  // Asking for a hint costs nothing — the learner still picks the answer — so neither flag
+  // is fed into scoring or into progress.
+  const [hintUnlocked, setHintUnlocked] = useState(false);
+  const [hintVisible, setHintVisible] = useState(false);
+  const [typed, setTyped] = useState(""); // the written answer, when this step is typed
 
   // Progress state: keyed by "card:<id>" or "tq:<id>"
   const [progress, setProgress] = useState<Record<string, ProgressEntry>>({});
@@ -89,6 +100,9 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     setQueue(items);
     setTotal(items.length);
     setIndex(0);
+    setHintUnlocked(false);
+    setHintVisible(false);
+    setTyped("");
   }
 
   useEffect(() => {
@@ -111,11 +125,18 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   const item = queue[index];
   const currentEntry = item ? (progress[`${item.sourceType}:${item.sourceID}`] ?? null) : null;
   const currentLevel = currentEntry?.level ?? 1;
+  // Written step: only for cards whose answer is the term (never the reverse direction,
+  // where it would mean writing out a whole definition) and only once well known.
+  const typingStep = !!item?.typable && currentLevel >= TYPE_FROM_LEVEL;
+  const expected = item?.options.find((o) => o.isCorrect)?.text ?? "";
+  const answered = typingStep ? typed.trim() !== "" : selected.size > 0;
 
   const submit = useCallback(() => {
-    if (submitted || selected.size === 0 || !item) return;
+    if (submitted || !item || !answered) return;
     const correctSet = new Set(item.options.filter((o) => o.isCorrect).map((o) => o.text));
-    const correct = selected.size === correctSet.size && [...selected].every((s) => correctSet.has(s));
+    const correct = typingStep
+      ? isTypedCorrect(typed, expected)
+      : selected.size === correctSet.size && [...selected].every((s) => correctSet.has(s));
     setIsCorrect(correct);
     setSubmitted(true);
     // On a retry, a correct answer redeems +1 (the wrong first attempt already
@@ -129,7 +150,7 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     // Score counts first attempts only; retries are practice.
     if (item.isRetry) return;
     if (correct) setScore((sc) => sc + 1);
-  }, [submitted, selected, item, currentLevel]);
+  }, [submitted, selected, item, currentLevel, answered, typingStep, typed, expected]);
 
   const next = useCallback(() => {
     if (!item) return;
@@ -171,6 +192,9 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     setSubmitted(false);
     setDisplayLevel(null);
     setConfidenceDelta(null);
+    setHintUnlocked(false);
+    setHintVisible(false);
+    setTyped("");
   }, [index, queue, item, isCorrect, confidenceDelta, displayLevel, currentLevel, collectionID, requeueWrongCards]);
 
   function handleConfidence(delta: -1 | 1) {
@@ -195,14 +219,20 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (!item) return;
-      const num = parseInt(e.key);
-      if (num >= 1 && num <= item.options.length) { e.preventDefault(); toggle(item.options[num - 1].text); }
-      if (e.code === "Enter") { e.preventDefault(); submitted ? next() : selected.size > 0 && submit(); }
+      // While a step is written, every key belongs to the answer — no option numbers, and
+      // no h shortcut for the hint (the bulb is still there to press).
+      if (!typingStep) {
+        const num = parseInt(e.key);
+        if (num >= 1 && num <= item.options.length) { e.preventDefault(); toggle(item.options[num - 1].text); }
+        // Keyboard has no hold gesture, so h toggles instead: press to read, press again to hide.
+        if (e.key === "h" && item.hint) { e.preventDefault(); setHintUnlocked(true); setHintVisible((v) => !v); }
+      }
+      if (e.code === "Enter") { e.preventDefault(); submitted ? next() : answered && submit(); }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item, submitted, selected, submit, next]);
+  }, [item, submitted, selected, submit, next, typingStep, answered]);
 
   if (error) {
     return (
@@ -277,24 +307,97 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
             <p className="text-xl font-semibold text-gray-900 dark:text-slate-100">{item.question}</p>
           </div>
 
-          <div className="flex flex-col gap-2">
-            {item.options.map((opt, i) => (
-              <OptionButton
-                key={i}
-                index={i}
-                text={opt.text}
-                multi={item.multi}
-                selected={selected.has(opt.text)}
-                submitted={submitted}
-                isCorrect={opt.isCorrect}
-                explanation={opt.explanation}
-                onClick={() => toggle(opt.text)}
-              />
-            ))}
-          </div>
+          {typingStep ? (
+            <div className="flex flex-col gap-2">
+              <div className="relative">
+                <span aria-hidden className="absolute left-4 top-1/2 -translate-y-1/2 text-lg pointer-events-none select-none">⌨️</span>
+                <input
+                  value={typed}
+                  onChange={(e) => setTyped(e.target.value)}
+                  readOnly={submitted}
+                  placeholder="Write the answer…"
+                  aria-label="Write the answer"
+                  data-testid="type-input"
+                  autoFocus
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className={`w-full rounded-xl border pl-12 pr-4 py-3 text-left text-lg focus:outline-none placeholder:text-gray-400 dark:placeholder:text-slate-500 ${
+                    !submitted
+                      ? "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
+                      : isCorrect
+                      ? "border-green-400 dark:border-green-600 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300"
+                      : "border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300"
+                  }`}
+                />
+              </div>
+              {submitted && !isCorrect && (
+                <p data-testid="type-answer" className="text-center text-sm text-gray-600 dark:text-slate-300">
+                  Correct answer: <span className="font-medium">{expected}</span>
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {item.options.map((opt, i) => (
+                <OptionButton
+                  key={i}
+                  index={i}
+                  text={opt.text}
+                  multi={item.multi}
+                  selected={selected.has(opt.text)}
+                  submitted={submitted}
+                  isCorrect={opt.isCorrect}
+                  explanation={opt.explanation}
+                  onClick={() => toggle(opt.text)}
+                />
+              ))}
+            </div>
+          )}
 
           <div className="flex items-center justify-between min-h-[44px]">
-            <p className="text-xs text-gray-400 dark:text-slate-500 hidden sm:block">Press 1–{item.options.length} to select · Enter to confirm</p>
+            <div className="flex items-center gap-2">
+              {/* A hint is offered, never pushed: the first press unlocks it, and after that it is
+                  only on screen while the learner asks for it — hovering with a mouse, holding the
+                  button on a touch screen. The popup floats above the row, so revealing it never
+                  moves the question or the options. */}
+              {item.hint && (
+                <div className="relative">
+                  <button
+                    type="button"
+                    data-testid="hint-button"
+                    onClick={() => { setHintUnlocked(true); setHintVisible(true); }}
+                    onMouseEnter={() => hintUnlocked && setHintVisible(true)}
+                    onMouseLeave={() => setHintVisible(false)}
+                    onBlur={() => setHintVisible(false)}
+                    // preventDefault keeps the tap from also firing a click, so hold-to-read and
+                    // press-to-unlock stay one gesture.
+                    onTouchStart={(e) => { e.preventDefault(); setHintUnlocked(true); setHintVisible(true); }}
+                    onTouchEnd={() => setHintVisible(false)}
+                    onTouchCancel={() => setHintVisible(false)}
+                    onContextMenu={(e) => e.preventDefault()}
+                    // No title: the browser's own tooltip would show up underneath our popup.
+                    aria-label="Show hint"
+                    className={`select-none text-base leading-none w-9 h-9 rounded-lg border transition-colors ${
+                      hintVisible
+                        ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+                        : "border-gray-300 dark:border-slate-600 hover:border-amber-300 dark:hover:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20"
+                    }`}
+                  >
+                    💡
+                  </button>
+                  {hintVisible && (
+                    <div
+                      role="tooltip"
+                      data-testid="hint-text"
+                      className="absolute top-0 left-full ml-2 z-10 w-72 max-w-[80vw] rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg px-4 py-3 text-left text-sm text-gray-600 dark:text-slate-300"
+                    >
+                      {item.hint}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
             <div className="flex items-center gap-2 ml-auto">
               {submitted && loggedIn && !item.isRetry && (
                 <div className="flex items-center gap-1">
@@ -328,7 +431,7 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
                   </button>
                 </div>
               )}
-              {!submitted && selected.size > 0 && (
+              {!submitted && answered && (
                 <button onClick={submit} className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors">
                   Confirm
                 </button>
@@ -340,6 +443,13 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
               )}
             </div>
           </div>
+
+          {/* Its own centred line under the buttons: sharing the row with them left it competing
+              with the hint button for the left edge. */}
+          <p className="-mt-3 text-xs text-center text-gray-400 dark:text-slate-500 hidden sm:block">
+            {typingStep ? "Enter to confirm" : `Press 1–${item.options.length} to select · Enter to confirm`}
+          </p>
+
         </div>
       </main>
     </div>

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -14,6 +14,9 @@ async function login(page: import("@playwright/test").Page) {
 // Test markers for items created by the import test — used for cleanup so runs don't
 // accumulate cards/quizzes in the shared seed collection.
 const E2E_CARD_TERM = "e2e-import-term";
+// Whole-text matcher. Playwright's hasText takes a string as a substring, so short seed
+// values ("go") match longer tiles; an anchored regex keeps a tile lookup exact.
+const exact = (text: string) => new RegExp(`^\\s*${text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`);
 const E2E_QUIZ_QUESTION = "e2e quiz?";
 
 // After every test, delete any items the suite created (identified by their markers)
@@ -49,13 +52,10 @@ test("collection detail shows card content via the item model", async ({ page })
 test("quizzes (former tests) are exercises, done via the Exercise session", async ({ page }) => {
   test.setTimeout(60_000);
   await login(page);
-  await page.getByText("Go Basics").first().click();
-  await page.waitForURL(/\/collections\/[0-9a-f-]+$/);
-  // Collection page offers the Exercise study button (quizzes aren't inline anymore).
-  const exercise = page.getByRole("link", { name: /^exercise$/i });
-  await expect(exercise).toBeVisible({ timeout: 30_000 });
-  await exercise.click();
-  await page.waitForURL(/\/exercises$/);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+  await page.goto(`/collections/${go!.ID}/exercises`);
   // The quiz renders as a QuizBlock in the session. It's a stepper (one block at a time),
   // so the quiz may not be the current slot — assert it's rendered, not necessarily shown.
   await expect(page.getByText("Which of the following declares a variable in Go?").first()).toBeAttached({ timeout: 30_000 });
@@ -221,11 +221,10 @@ test("Match game: enabled with ≥5 cards, board renders and tiles flip", async 
   const expectedTiles = 2 * Math.min(cardCount, 10);
 
   await page.goto(`/collections/${go!.ID}`);
-  // Match lives in the 🎮 games menu now.
-  const gamesBtn = page.getByRole("button", { name: "Mini games" });
-  await expect(gamesBtn).toBeVisible({ timeout: 30_000 });
-  await gamesBtn.click();
-  await page.getByRole("button", { name: /Match/ }).click();
+  // Each mini-game is its own button next to Blitz.
+  const matchBtn = page.getByRole("link", { name: /Match/ });
+  await expect(matchBtn).toBeVisible({ timeout: 30_000 });
+  await matchBtn.click();
   await page.waitForURL(/\/match$/);
 
   const tiles = page.getByTestId("match-tile");
@@ -269,12 +268,12 @@ test("Match game: inactive when a collection has fewer than 5 cards", async ({ p
   expect((detail.Cards ?? []).length, "Private Notes should have <5 cards").toBeLessThan(5);
 
   await page.goto(`/collections/${pn!.ID}`);
-  // The 🎮 games menu is shown but inactive — rendered as plain text, not a button.
-  await expect(page.getByText("🎮")).toBeVisible({ timeout: 30_000 });
-  await expect(page.getByRole("button", { name: "Mini games" })).toHaveCount(0);
+  // The mini-game buttons are shown but inactive — rendered as plain text, not links.
+  await expect(page.getByLabel("Match")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("link", { name: /Match/ })).toHaveCount(0);
 });
 
-test("Connect game: link matching pairs via the 🎮 menu, Check reports all correct", async ({ page }) => {
+test("Connect game: link matching pairs, Check reports all correct", async ({ page }) => {
   test.setTimeout(60_000);
   await login(page);
   const cols = await (await page.request.get(`${API}/collections`)).json();
@@ -286,27 +285,168 @@ test("Connect game: link matching pairs via the 🎮 menu, Check reports all cor
   expect(cards.length).toBeLessThanOrEqual(7);
 
   await page.goto(`/collections/${go!.ID}`);
-  await page.getByRole("button", { name: "Mini games" }).click();
-  await page.getByRole("button", { name: /Connect/ }).click();
+  await page.getByRole("link", { name: /Connect/ }).click();
   await page.waitForURL(/\/connect$/);
   await expect(page.getByTestId("connect-term")).toHaveCount(cards.length, { timeout: 30_000 });
 
   // Link each card's term to its definition (both are visible on the board).
   for (const c of cards) {
-    await page.getByTestId("connect-term").filter({ hasText: c.Term }).first().click();
-    await page.getByTestId("connect-def").filter({ hasText: c.Definition }).first().click();
+    await page.getByTestId("connect-term").filter({ hasText: exact(c.Term) }).first().click();
+    await page.getByTestId("connect-def").filter({ hasText: exact(c.Definition) }).first().click();
   }
   await page.getByRole("button", { name: "Check" }).click();
   await expect(page.getByText(`${cards.length} / ${cards.length} correct`)).toBeVisible({ timeout: 10_000 });
 });
 
-test("blitz session loads a card question", async ({ page }) => {
+test("blitz session loads a card question once the exercises are done", async ({ page }) => {
+  test.setTimeout(60_000);
   await login(page);
-  await page.getByText("Go Basics").first().click();
-  await page.waitForURL(/\/collections\/[0-9a-f-]+$/);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+  const detail = await (await page.request.get(`${API}/collections/${go!.ID}`)).json();
+  const exs = (detail.Exercises ?? []) as Array<{ ID: string; Kind: string; Options?: { text: string; is_correct: boolean }[]; Sentences?: { id: string; answer: string[] }[] }>;
+
+  // Blitz runs unanswered exercises before the cards, so answer them first — this test is
+  // about the card phase.
+  const results = exs.flatMap((e) =>
+    e.Kind === "quiz"
+      ? [{ sentence_id: e.ID, correct: true, submitted: [e.Options!.find((o) => o.is_correct)!.text] }]
+      : e.Sentences!.map((sn) => ({ sentence_id: sn.id, correct: true, submitted: sn.answer }))
+  );
+  const rec = await page.request.post(`${API}/collections/${go!.ID}/exercises/results`, { data: { results } });
+  expect(rec.ok()).toBeTruthy();
+
+  await page.goto(`/collections/${go!.ID}`);
   const blitz = page.getByRole("link", { name: /blitz/i }).or(page.getByRole("button", { name: /blitz/i }));
   await blitz.first().click();
   await page.waitForURL(/\/blitz/);
   // Blitz renders one of the seed card definitions/terms as the prompt.
   await expect(page.locator("body")).toContainText(/goroutine|defer|channel|pointer/i);
+});
+
+// ── Search, paging and the typing game, all over the 30-word dictionary ──────────────
+
+async function dictionary(page: import("@playwright/test").Page) {
+  const cols = await (await page.request.get(`${API}/public/collections`)).json();
+  const dict = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "English Vocabulary");
+  expect(dict, "seed dictionary present").toBeTruthy();
+  return dict!.ID;
+}
+
+test("collection search filters the list and clears again", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const id = await dictionary(page);
+  await page.goto(`/collections/${id}`);
+
+  const search = page.getByTestId("item-search");
+  await expect(search).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("vivid")).toHaveCount(0); // page 2 material
+
+  // Fuzzy: a subsequence of the term is enough, and it is found wherever it lives.
+  await search.fill("vvd");
+  await expect(page.getByText("vivid").first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("abundant")).toHaveCount(0);
+
+  await page.getByLabel("Clear search").click();
+  await expect(page.getByText("abundant").first()).toBeVisible();
+});
+
+test("collection list pages at 20 items", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const id = await dictionary(page);
+  await page.goto(`/collections/${id}`);
+
+  const indicator = page.getByTestId("page-indicator");
+  await expect(indicator).toHaveText("1 / 2", { timeout: 30_000 });
+  // 30 words: twenty on the first page, the rest on the second.
+  await expect(page.getByText("abundant").first()).toBeVisible();
+  await expect(page.getByText("vivid")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "→" }).click();
+  await expect(indicator).toHaveText("2 / 2");
+  await expect(page.getByText("vivid").first()).toBeVisible();
+  await expect(page.getByText("abundant")).toHaveCount(0);
+});
+
+test("typing game: seven cards, wrong answer shows the term", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const id = await dictionary(page);
+  await page.goto(`/collections/${id}/type`);
+
+  const input = page.getByTestId("type-input");
+  await expect(input).toBeVisible({ timeout: 30_000 });
+  // A round is capped at seven cards even though the deck holds thirty.
+  await expect(page.getByText("1 / 7")).toBeVisible();
+
+  await input.fill("definitely not the term");
+  await page.getByRole("button", { name: "Check" }).click();
+  await expect(page.getByTestId("type-answer")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: /^Next/ }).click();
+  await expect(page.getByText("2 / 7")).toBeVisible();
+});
+
+test("flashcards show a card's hint on the back, in its own card", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+
+  await page.goto(`/collections/${go!.ID}/cards`);
+  const term = page.getByText(/^(What|Which|Zero)/).first();
+  await expect(term).toBeVisible({ timeout: 30_000 });
+  // Front: no hint. Flip through the deck until a card with one turns up — four of the
+  // five seed cards have a hint, so this lands well inside the deck.
+  await expect(page.getByTestId("hint-card")).toHaveCount(0);
+  for (let i = 0; i < 5; i++) {
+    await page.keyboard.press("Space");
+    if (await page.getByTestId("hint-card").count()) break;
+    await page.keyboard.press("Enter"); // next card, front side
+  }
+  await expect(page.getByTestId("hint-card")).toBeVisible();
+});
+
+test("match: a completed pair is recorded as progress", async ({ page }) => {
+  test.setTimeout(90_000);
+  await login(page);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+  // Start from a known state: no levels at all for this collection.
+  await page.request.delete(`${API}/collections/${go!.ID}/progress`);
+
+  const detail = await (await page.request.get(`${API}/collections/${go!.ID}`)).json();
+  const cards = (detail.Cards ?? []) as Array<{ ID: string; Term: string; Definition: string }>;
+
+  await page.goto(`/collections/${go!.ID}/match`);
+  const terms = page.getByTestId("match-side").first().getByTestId("match-tile");
+  const defs = page.getByTestId("match-side").last().getByTestId("match-tile");
+  await expect(terms.first()).toBeVisible({ timeout: 30_000 });
+
+  // Face-down tiles render "?", so the pair cannot be located up front — open the first
+  // term and try definitions until one sticks. A mismatch hides both again after its
+  // reveal window, so the term is reopened before the next try.
+  const term = terms.first();
+  await term.click();
+  const shownTerm = (await term.innerText()).trim();
+  let matched = false;
+  for (let j = 0; j < (await defs.count()); j++) {
+    await defs.nth(j).click();
+    await page.waitForTimeout(1500); // MISMATCH_MS plus a margin
+    if ((await term.getAttribute("data-facing")) === "up") { matched = true; break; }
+    await term.click();
+  }
+  expect(matched, "one pair was completed").toBeTruthy();
+
+  const card = cards.find((c) => c.Term === shownTerm);
+  expect(card, `board term "${shownTerm}" is a card of the collection`).toBeTruthy();
+  await expect(async () => {
+    const prog = await (await page.request.get(`${API}/collections/${go!.ID}/progress`)).json();
+    expect(prog.cards[card!.ID]?.level, "matched card rose from level 1").toBe(2);
+  }).toPass({ timeout: 15_000 });
 });

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -108,6 +108,9 @@ export type Card = {
   CollectionID: string;
   Term: string;
   Definition: string;
+  // Optional guidance the learner can reveal while studying — a mnemonic, a warning about an
+  // irregular form. Empty string when the card has none.
+  Hint: string;
   Image: string;
   Position: number;
   CreatedAt: string;
@@ -353,10 +356,10 @@ export const api = {
       request<void>(`/admin/collections/${collectionID}`, { method: "DELETE" }),
   },
   cards: {
-    add: (collectionID: string, term: string, definition: string, image: string, position: number) =>
-      request<Card>(`/collections/${collectionID}/cards`, { method: "POST", body: JSON.stringify({ term, definition, image, position }) }),
-    update: (collectionID: string, cardID: string, term: string, definition: string, position: number) =>
-      request<Card>(`/collections/${collectionID}/cards/${cardID}`, { method: "PUT", body: JSON.stringify({ term, definition, position }) }),
+    add: (collectionID: string, term: string, definition: string, image: string, hint: string, position: number) =>
+      request<Card>(`/collections/${collectionID}/cards`, { method: "POST", body: JSON.stringify({ term, definition, image, hint, position }) }),
+    update: (collectionID: string, cardID: string, term: string, definition: string, hint: string, position: number) =>
+      request<Card>(`/collections/${collectionID}/cards/${cardID}`, { method: "PUT", body: JSON.stringify({ term, definition, hint, position }) }),
     delete: (collectionID: string, cardID: string) =>
       request<void>(`/collections/${collectionID}/cards/${cardID}`, { method: "DELETE" }),
     import: (collectionID: string, file: File) => {

--- a/lib/fuzzy.test.ts
+++ b/lib/fuzzy.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyScore, fuzzyBest } from "./fuzzy";
+
+describe("fuzzyScore", () => {
+  it("matches a subsequence, not just a substring", () => {
+    expect(fuzzyScore("gorot", "What is a goroutine?")).not.toBeNull();
+    expect(fuzzyScore("goxt", "What is a goroutine?")).toBeNull();
+  });
+
+  it("ignores case and diacritics", () => {
+    expect(fuzzyScore("loffel", "der Löffel")).not.toBeNull();
+    expect(fuzzyScore("REVOIR", "Au revoir")).not.toBeNull();
+  });
+
+  it("ranks a run of adjacent characters above scattered ones", () => {
+    const adjacent = fuzzyScore("chan", "channel")!;
+    const scattered = fuzzyScore("chan", "the cook has a nap")!;
+    expect(adjacent).toBeGreaterThan(scattered);
+  });
+
+  it("ranks a word start above a match inside a word", () => {
+    const atStart = fuzzyScore("de", "defer runs late")!;
+    const inside = fuzzyScore("de", "a wide net")!;
+    expect(atStart).toBeGreaterThan(inside);
+  });
+
+  it("prefers the shorter text when the match is otherwise equal", () => {
+    const short = fuzzyScore("go", "go")!;
+    const long = fuzzyScore("go", "go and then a great many other words follow here")!;
+    expect(short).toBeGreaterThan(long);
+  });
+
+  it("treats an empty query as no filter", () => {
+    expect(fuzzyScore("", "anything")).toBe(0);
+    expect(fuzzyScore("   ", "anything")).toBe(0);
+  });
+
+  it("skips spaces in the query so words can be typed in order", () => {
+    expect(fuzzyScore("zero pointer", "Zero value of a pointer?")).not.toBeNull();
+  });
+});
+
+describe("fuzzyBest", () => {
+  it("returns the best-scoring field and ignores empty ones", () => {
+    const best = fuzzyBest("spoon", ["der Löffel", "spoon", "", undefined]);
+    expect(best).toBe(fuzzyScore("spoon", "spoon"));
+  });
+
+  it("is null when nothing matches", () => {
+    expect(fuzzyBest("xyz", ["der Löffel", "spoon"])).toBeNull();
+  });
+});

--- a/lib/fuzzy.ts
+++ b/lib/fuzzy.ts
@@ -1,0 +1,64 @@
+// Subsequence fuzzy matching for the in-collection search — no dependency, and small
+// enough to score a few hundred items on every keystroke.
+//
+// A query matches when all of its characters appear in the text in order, not necessarily
+// adjacent: "gorot" finds "What is a goroutine?". Scoring favours matches that look
+// deliberate — runs of adjacent characters, and characters landing at the start of a word —
+// so a typed prefix beats letters scattered across a sentence.
+
+// Diacritics are stripped so "Lo" finds "der Löffel" and "revoir" finds "Au revoir".
+function normalize(s: string): string {
+  return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+}
+
+function isWordStart(text: string, i: number): boolean {
+  if (i === 0) return true;
+  return /[\s\-_/(),.;:'"]/.test(text[i - 1]);
+}
+
+const ADJACENT = 8; // the previous query character matched the previous text character
+const WORD_START = 6; // this character opens a word
+const BASE = 1; // every matched character is worth something
+
+/**
+ * Score how well `query` matches `text`. Returns null when the query is not a subsequence
+ * of the text; otherwise a number where higher is a better match. An empty query scores 0,
+ * which callers read as "no filter".
+ */
+export function fuzzyScore(query: string, text: string): number | null {
+  const q = normalize(query.trim());
+  if (q === "") return 0;
+  const t = normalize(text);
+
+  let score = 0;
+  let ti = 0;
+  let prevMatch = -2; // index of the previously matched character in the text
+  for (const ch of q) {
+    // Whitespace in the query is a separator, not something to find in the text.
+    if (ch === " ") continue;
+    const found = t.indexOf(ch, ti);
+    if (found === -1) return null;
+    score += BASE;
+    if (found === prevMatch + 1) score += ADJACENT;
+    if (isWordStart(t, found)) score += WORD_START;
+    prevMatch = found;
+    ti = found + 1;
+  }
+  // A short text carrying the same match is the more precise hit: "go" should rank the card
+  // whose term is "go" above a sentence that merely contains those letters.
+  return score - Math.min(t.length, 200) / 100;
+}
+
+/**
+ * Best score across several fields of one item (term, definition, hint, …). Null when the
+ * query matches none of them.
+ */
+export function fuzzyBest(query: string, texts: (string | undefined | null)[]): number | null {
+  let best: number | null = null;
+  for (const text of texts) {
+    if (!text) continue;
+    const s = fuzzyScore(query, text);
+    if (s !== null && (best === null || s > best)) best = s;
+  }
+  return best;
+}

--- a/lib/session.test.ts
+++ b/lib/session.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { fromCards, fromBlitz } from "./session";
 import type { Card, BlitzResponse } from "./api";
 
-function card(id: string, term: string, definition: string): Card {
-  return { ID: id, CollectionID: "c", Term: term, Definition: definition, Image: "", Position: 0, CreatedAt: "", UpdatedAt: "" };
+function card(id: string, term: string, definition: string, hint = ""): Card {
+  return { ID: id, CollectionID: "c", Term: term, Definition: definition, Hint: hint, Image: "", Position: 0, CreatedAt: "", UpdatedAt: "" };
 }
 
 const deck: Card[] = [
@@ -63,5 +63,17 @@ describe("fromBlitz", () => {
       expect(it.speakText).toBe(src.Term);
       expect(it.options.length).toBeLessThanOrEqual(4);
     }
+  });
+
+  // A hint describes the card, not the side being asked about, so it survives either
+  // direction — the session UI decides whether to offer it, not the builder.
+  it("carries a card's hint in both directions", () => {
+    const hinted = card("h", "der Löffel", "spoon", "masculine");
+    const items = fromBlitz({
+      items: [{ type: "card" as const, card: hinted }],
+      card_pool: [{ ID: hinted.ID, Term: hinted.Term, Definition: hinted.Definition }],
+    });
+    expect(items[0].hint).toBe("masculine");
+    expect(fromCards([hinted])[0].hint).toBe("masculine");
   });
 });

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -19,6 +19,13 @@ export type SessionItem = {
   // speak immediately; otherwise (term is an answer option) speaking it before the
   // answer is revealed would spoil it, so the UI gates on submission.
   speakText?: string;
+  // The card's hint, revealed on request before answering. Cards only — quiz options
+  // already carry their own explanation, shown after the answer.
+  hint?: string;
+  // The correct answer is the card's term, so it is short enough to write from memory.
+  // A session may then ask a well-known card to be typed instead of picked. Never set on
+  // the reverse direction, where the answer is a whole definition.
+  typable?: boolean;
 };
 
 function shuffle<T>(arr: T[]): T[] {
@@ -52,6 +59,8 @@ export function fromCards(cards: Card[]): SessionItem[] {
         badge: { text: "Single answer", className: "bg-gray-100 text-gray-500" },
         sourceID: card.ID,
         sourceType: "card" as const,
+        hint: card.Hint,
+        typable: true,
       };
     })
   );
@@ -101,6 +110,10 @@ export function fromBlitz(result: BlitzResponse): SessionItem[] {
         sourceType: "card" as const,
         regenOptions: () => buildCardOptions(card.ID, correct),
         speakText: card.Term,
+        // Shown in either direction: a hint is guidance about the card, not its answer, so
+        // it stays useful whether the learner is picking the term or the definition.
+        hint: card.Hint,
+        typable: !reverse,
       };
     } else {
       const q = item.tq;

--- a/lib/typing.test.ts
+++ b/lib/typing.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { normalizeAnswer, isTypedCorrect } from "./typing";
+
+describe("normalizeAnswer", () => {
+  it("levels out case, edges, repeated spaces and trailing punctuation", () => {
+    expect(normalizeAnswer("  Der   Löffel.  ")).toBe("der löffel");
+    expect(normalizeAnswer("go!")).toBe("go");
+  });
+});
+
+describe("isTypedCorrect", () => {
+  it("accepts the term however it was capitalised or spaced", () => {
+    expect(isTypedCorrect(" GOROUTINE ", "goroutine")).toBe(true);
+  });
+
+  it("keeps accents significant — they are part of the spelling", () => {
+    expect(isTypedCorrect("Loffel", "Löffel")).toBe(false);
+    expect(isTypedCorrect("löffel", "Löffel")).toBe(true);
+  });
+
+  it("accepts any alternative when the term lists them with a slash", () => {
+    const term = "der Löffel / Löffel";
+    expect(isTypedCorrect("löffel", term)).toBe(true);
+    expect(isTypedCorrect("der löffel", term)).toBe(true);
+    expect(isTypedCorrect("die gabel", term)).toBe(false);
+  });
+
+  it("rejects an empty answer", () => {
+    expect(isTypedCorrect("   ", "go")).toBe(false);
+  });
+});

--- a/lib/typing.ts
+++ b/lib/typing.ts
@@ -1,0 +1,25 @@
+// Answer checking for the typing mini-game: the learner reads a definition and writes the
+// term from memory. Pure, so the rules are testable without a keyboard.
+
+// What a learner is actually being asked to recall is the word, not its punctuation or how
+// many spaces they hit. Case, surrounding whitespace, repeated spaces and trailing marks are
+// therefore levelled out before comparing — but letters are not: an accent is part of the
+// spelling in the languages this app is used for, so "Loffel" is not "Löffel".
+export function normalizeAnswer(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.,;:!?]+$/, "");
+}
+
+/**
+ * Is `typed` an acceptable rendering of `term`? A term written with alternatives separated by
+ * a slash ("der Löffel / Löffel") accepts any one of them — that is how such cards are
+ * written, and demanding the whole string would fail a learner who knows the word.
+ */
+export function isTypedCorrect(typed: string, term: string): boolean {
+  const got = normalizeAnswer(typed);
+  if (got === "") return false;
+  return term.split("/").map(normalizeAnswer).filter(Boolean).includes(got);
+}


### PR DESCRIPTION
Opened from `vibe-dev`, which is where work in this repo happens. Pairs with cram-back#26 — that side stores and serves the hint, this side is where a learner meets it.

## Hints

A card's hint needed somewhere to appear, and the answer differs per mode because the risk of spoiling the round does.

In **blitz** and in the typing game it sits behind a bulb in the action row. The first press unlocks it; after that it is on screen only while asked for — hovering with a mouse, holding the button on a touch screen. The popup floats above the row, so reading a hint never moves the question or the options. Asking costs nothing: neither flag reaches scoring or progress, because the learner still has to answer.

On the **flashcards** there is no button. Flipping already gave the answer away, so a hint held back until a second click would only be one more click; it appears with the back side, in a card of its own. In the **collection list** it shows next to the definition — that list is for reviewing and editing content, not for testing yourself on it.

## A typing mini-game, and typing inside blitz

⌨️ **Type** shows the definition and asks for the term with nothing to recognise. Checking lives in `lib/typing`: case, edges, repeated spaces and trailing punctuation are levelled out; accents are not, since they are part of the spelling in the languages this is used for; a term written with slashed alternatives accepts any one of them. A round is seven cards, the same length as blitz — writing from memory is the slowest of the modes.

The same step appears **inside blitz once a card reaches level 5**. Picking one of four options stops proving anything that far in. It is limited to cards whose answer is the term: in the reverse direction it would mean writing out a whole definition. While a step is written, the option-number and hint shortcuts are released to the answer.

Progress is reported for both outcomes here, unlike match — writing a term from memory is real recall, so a miss is a real miss.

## Session and navigation changes

- **Blitz runs the collection's unanswered exercises first**, then the cards. The Exercise button is therefore gone: an answered exercise is redone through the editor's reset, which clears exactly the saved answers blitz reads.
- **Mini-games are buttons instead of a 🎮 menu**, and the 🎲 random pick is gone.
- **A completed match pair counts as a correct answer.** Mismatches report nothing — turning over the wrong tile is how a memory board gets explored, and a wrong answer halves the level. Repeat rounds cannot inflate anything either: the server ignores a correct answer given before the card is due.

## Search and paging

Collections past five items get a **fuzzy search** (`lib/fuzzy`: subsequence matching, bonuses for adjacent characters and word starts, diacritics folded, shorter texts preferred), and the list **pages at twenty**. The order is what keeps them compatible: the query runs over the whole collection and only its results are sliced, so a search never sees one page. Neither applies in edit mode, where a reorder computes an item's rank from its neighbours in the rendered list and a filtered list would hand it the wrong ones.

## Testing

`vitest` 52/52 and `playwright` 19/19 against a local stack.

Five specs added: search, paging, the seven-card typing round, the hint on a flashcard back, and match writing progress — the last one plays the board for real, since face-down tiles keep their text out of the DOM.

Three existing specs were repaired. Two drove UI this branch removes. The third is worth naming: the connect spec matched tile text as a substring, so the seed definition `go` also matched "…managed by the Go runtime" and the wrong tile was clicked whenever the shuffle put it first — it failed at random, before this branch and after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)