### PR TITLE
Spell the typed answer from offered letters

### DIFF
--- a/app/collections/[id]/type/page.tsx
+++ b/app/collections/[id]/type/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { api, Card } from "@/lib/api";
+import { api, Card, type ProgressEntry } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
 import Navbar from "@/components/Navbar";
-import { isTypedCorrect } from "@/lib/typing";
+import TypeAnswer, { useGuidedAnswer } from "@/components/TypeAnswer";
+import LevelDot from "@/components/LevelDot";
+import { lettersOf } from "@/lib/typing";
+import { applyAnswer, nextReviewFromLevel } from "@/lib/progress";
 
 const SESSION_SIZE = 7; // cards per round, matching blitz
 
@@ -18,7 +21,6 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
   const [collectionID, setCollectionID] = useState("");
   const [cards, setCards] = useState<Card[]>([]);
   const [index, setIndex] = useState(0);
-  const [typed, setTyped] = useState("");
   const [verdict, setVerdict] = useState<"right" | "wrong" | null>(null);
   const [score, setScore] = useState(0);
   const [done, setDone] = useState(false);
@@ -27,7 +29,10 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
   // asked for. Asking costs nothing — the term still has to be typed.
   const [hintUnlocked, setHintUnlocked] = useState(false);
   const [hintVisible, setHintVisible] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  // Where each card stands, so this mode carries the same level dot as blitz. The level shown
+  // moves the moment a verdict lands and is then trued up from the server's own answer.
+  const [progress, setProgress] = useState<Record<string, ProgressEntry>>({});
+  const [displayLevel, setDisplayLevel] = useState<number | null>(null);
 
   useEffect(() => {
     props.params.then(({ id }) => {
@@ -46,36 +51,69 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
   }, [props.params]);
 
   useEffect(() => {
+    if (!isLoggedIn() || !collectionID) return;
+    api.progress.get(collectionID).then((data) => setProgress(data.cards)).catch(() => {});
+  }, [collectionID]);
+
+  useEffect(() => {
     if (!done || !collectionID) return;
     const t = setTimeout(() => router.replace(`/collections/${collectionID}`), 1700);
     return () => clearTimeout(t);
   }, [done, collectionID, router]);
 
   const card = cards[index];
+  const currentEntry = card ? (progress[card.ID] ?? null) : null;
+  const currentLevel = currentEntry?.level ?? 1;
+  const shownLevel = displayLevel ?? currentLevel;
 
-  // Keep the caret in the box between cards — this mode is played entirely from the keyboard.
-  useEffect(() => { inputRef.current?.focus(); }, [index, verdict]);
+  // The decoys are drawn from the letters this deck actually uses, so the letters offered
+  // stay in the language being learnt.
+  const pool = useMemo(() => lettersOf(cards.map((c) => c.Term)), [cards]);
 
-  const check = useCallback(() => {
-    if (!card || verdict !== null || typed.trim() === "") return;
-    const right = isTypedCorrect(typed, card.Term);
+  // There is nothing to check: a wrong letter is never written down, so the card ends of its
+  // own accord — spelled out, or three wrong picks in.
+  const finish = useCallback((right: boolean) => {
+    if (!card || verdict !== null) return;
     setVerdict(right ? "right" : "wrong");
     if (right) setScore((s) => s + 1);
+    setDisplayLevel(applyAnswer(currentLevel, right, currentEntry?.next_review_at));
     if (isLoggedIn() && collectionID) {
       // Unlike match, a wrong answer here is a real failure of recall, not the cost of
       // exploring a board, so it is reported as one.
-      api.progress.update(collectionID, "card", card.ID, right, 0).catch(() => {});
+      api.progress.update(collectionID, "card", card.ID, right, 0)
+        .then((res) => setProgress((prev) => ({ ...prev, [card.ID]: { level: res.level, next_review_at: res.next_review_at } })))
+        .catch(() => {});
     }
-  }, [card, typed, verdict, collectionID]);
+  }, [card, verdict, collectionID, currentLevel, currentEntry?.next_review_at]);
+
+  const answer = useGuidedAnswer(card?.Term ?? "", finish);
+  const resetAnswer = answer.reset;
 
   const next = useCallback(() => {
     setVerdict(null);
-    setTyped("");
+    resetAnswer();
+    setDisplayLevel(null);
     setHintUnlocked(false);
     setHintVisible(false);
     if (index + 1 >= cards.length) { setDone(true); return; }
     setIndex((i) => i + 1);
-  }, [index, cards.length]);
+  }, [index, cards.length, resetAnswer]);
+
+  // Enter lives on the window now that there is no text field to hang it off; the letters
+  // themselves are handled inside TypeAnswer.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Enter") return;
+      // A focused Next button already answers to Enter itself; handling it here as well would
+      // advance two cards on one press.
+      if ((e.target as HTMLElement | null)?.tagName === "BUTTON") return;
+      if (verdict === null) return;
+      e.preventDefault();
+      next();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [verdict, next]);
 
   if (error) {
     return (
@@ -115,20 +153,20 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
     );
   }
 
-  const inputTint =
-    verdict === "right" ? "border-green-400 dark:border-green-600 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300"
-    : verdict === "wrong" ? "border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300"
-    : "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100";
-
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
       {/* Same three-row grid as the flashcards: the prompt stays put whether or not a verdict
           and a hint are showing underneath. */}
       <main className="flex-1 grid grid-rows-[1fr_auto_1fr] px-4">
+        {/* Same furniture as a blitz step: how far in, how well this card is known, and what
+            kind of item it is. */}
         <div className="self-end mx-auto mb-3 w-full max-w-lg flex items-center justify-between">
-          <p className="text-xs text-gray-400 dark:text-slate-500 uppercase tracking-wide">Write the term</p>
           <p className="text-sm text-gray-400 dark:text-slate-500">{index + 1} / {cards.length}</p>
+          <div className="flex items-center gap-2">
+            {isLoggedIn() && <LevelDot level={shownLevel} nextReviewAt={nextReviewFromLevel(shownLevel)} />}
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-100 text-purple-600">Card</span>
+          </div>
         </div>
 
         <div className="mx-auto w-full max-w-lg min-h-48 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-sm flex flex-col items-center justify-center p-8 text-center gap-4">
@@ -136,31 +174,7 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
         </div>
 
         <div className="self-start mx-auto mt-3 w-full max-w-lg flex flex-col gap-3">
-          <div className="relative">
-            {/* Decorative, like the collection search's glass: the label already names the
-                field, and the icon must not eat clicks meant for the input. */}
-            <span aria-hidden className="absolute left-4 top-1/2 -translate-y-1/2 text-lg pointer-events-none select-none">⌨️</span>
-          <input
-            ref={inputRef}
-            value={typed}
-            onChange={(e) => setTyped(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); verdict === null ? check() : next(); } }}
-            readOnly={verdict !== null}
-            placeholder="Type the term…"
-            aria-label="Type the term"
-            data-testid="type-input"
-            autoFocus
-            autoComplete="off"
-            autoCorrect="off"
-            spellCheck={false}
-            // Left-aligned throughout: the caret starts at the placeholder's first letter and
-            // stays where the typing left it. Centring only the typed text would shift every
-            // character already written on each new keystroke.
-            // No focus ring: the field is focused the whole time in this mode, so a permanent
-            // blue halo says nothing and fights the green/red verdict tint for attention.
-            className={`w-full rounded-xl border pl-12 pr-4 py-3 text-left text-lg focus:outline-none placeholder:text-gray-400 dark:placeholder:text-slate-500 ${inputTint}`}
-          />
-          </div>
+          <TypeAnswer term={card.Term} pool={pool} verdict={verdict} {...answer} />
 
           {/* Only shown after a wrong answer: seeing the right spelling is the whole lesson. */}
           {verdict === "wrong" && (
@@ -205,24 +219,18 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
                 )}
               </div>
             ) : <span />}
-            {verdict === null ? (
-              <button
-                onClick={check}
-                disabled={typed.trim() === ""}
-                className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 disabled:opacity-40 transition-colors"
-              >
-                Check
-              </button>
-            ) : (
+            {/* Nothing to press until the card has ended: the letters themselves are the
+                whole interaction. */}
+            {verdict === null ? <span /> : (
               <button onClick={next} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 transition-colors">
                 {index + 1 >= cards.length ? "Finish" : "Next →"}
               </button>
             )}
           </div>
 
-          <p className="-mt-1 text-xs text-center text-gray-400 dark:text-slate-500">
-            Enter to {verdict === null ? "check" : "continue"}
-          </p>
+          {verdict !== null && (
+            <p className="-mt-1 text-xs text-center text-gray-400 dark:text-slate-500">Enter to continue</p>
+          )}
         </div>
       </main>
 

--- a/components/StudySession.tsx
+++ b/components/StudySession.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Navbar from "@/components/Navbar";
 import OptionButton from "@/components/OptionButton";
+import TypeAnswer, { useGuidedAnswer } from "@/components/TypeAnswer";
 import SpeakButton from "@/components/SpeakButton";
 import LevelDot from "@/components/LevelDot";
 import { api, type ProgressEntry } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
-import { isTypedCorrect } from "@/lib/typing";
+import { lettersOf } from "@/lib/typing";
+import { applyAnswer, applyConfidence, nextReviewFromLevel } from "@/lib/progress";
 import type { SessionItem } from "@/lib/session";
 
 // From this level on, a card is asked to be written rather than picked: recognising one of
@@ -34,37 +36,6 @@ function reshuffleOptions(options: SessionItem["options"]): SessionItem["options
   return a;
 }
 
-function applyAnswer(level: number, correct: boolean, nextReviewAt?: string): number {
-  if (level === 7) return 7;
-  if (correct) {
-    if (level === 1) return 2;
-    if (nextReviewAt && new Date(nextReviewAt) > new Date()) return level;
-    return Math.min(level + 1, 6);
-  }
-  return Math.max(1, Math.floor(level / 2));
-}
-
-function applyConfidence(level: number, delta: number): number {
-  if (delta === 1) return level >= 6 ? 7 : level + 1;
-  if (delta === -1) return Math.max(1, Math.floor(level / 2));
-  return level;
-}
-
-function nextReviewFromLevel(level: number): string {
-  const now = Date.now();
-  const day = 86400000;
-  const dates: Record<number, number> = {
-    1: now + day,
-    2: now + 2 * day,
-    3: now + 7 * day,
-    4: now + 14 * day,
-    5: now + 30 * day,
-    6: now + 180 * day,
-  };
-  if (level === 7) return "2099-12-31T00:00:00Z";
-  return new Date(dates[level] ?? now + day).toISOString();
-}
-
 export default function StudySession({ items, collectionID, doneTitle, error, requeueWrongCards }: Props) {
   const router = useRouter();
   const loggedIn = isLoggedIn();
@@ -85,7 +56,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   // is fed into scoring or into progress.
   const [hintUnlocked, setHintUnlocked] = useState(false);
   const [hintVisible, setHintVisible] = useState(false);
-  const [typed, setTyped] = useState(""); // the written answer, when this step is typed
 
   // Progress state: keyed by "card:<id>" or "tq:<id>"
   const [progress, setProgress] = useState<Record<string, ProgressEntry>>({});
@@ -102,7 +72,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     setIndex(0);
     setHintUnlocked(false);
     setHintVisible(false);
-    setTyped("");
   }
 
   useEffect(() => {
@@ -129,13 +98,21 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   // where it would mean writing out a whole definition) and only once well known.
   const typingStep = !!item?.typable && currentLevel >= TYPE_FROM_LEVEL;
   const expected = item?.options.find((o) => o.isCorrect)?.text ?? "";
-  const answered = typingStep ? typed.trim() !== "" : selected.size > 0;
+  // Only a chosen option counts as an answer to confirm: a written step ends itself, on its
+  // own last letter or its third mistake.
+  const answered = selected.size > 0;
+  // Decoy letters on the written step come from the letters this session's own answers use,
+  // so the alphabet offered stays that of the deck.
+  const pool = useMemo(() => lettersOf(items.map((it) => it.options.find((o) => o.isCorrect)?.text ?? "")), [items]);
 
-  const submit = useCallback(() => {
-    if (submitted || !item || !answered) return;
+  // `written` is the outcome of a written step, handed over by the guided answer that ended
+  // it. It also stands in for `answered`: a step failed on mistakes alone ends with nothing
+  // written down at all.
+  const submit = useCallback((written?: boolean) => {
+    if (submitted || !item || (written === undefined && !answered)) return;
     const correctSet = new Set(item.options.filter((o) => o.isCorrect).map((o) => o.text));
     const correct = typingStep
-      ? isTypedCorrect(typed, expected)
+      ? written === true
       : selected.size === correctSet.size && [...selected].every((s) => correctSet.has(s));
     setIsCorrect(correct);
     setSubmitted(true);
@@ -150,7 +127,10 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     // Score counts first attempts only; retries are practice.
     if (item.isRetry) return;
     if (correct) setScore((sc) => sc + 1);
-  }, [submitted, selected, item, currentLevel, answered, typingStep, typed, expected]);
+  }, [submitted, selected, item, currentLevel, answered, typingStep]);
+
+  const answer = useGuidedAnswer(expected, submit);
+  const resetAnswer = answer.reset;
 
   const next = useCallback(() => {
     if (!item) return;
@@ -194,8 +174,10 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     setConfidenceDelta(null);
     setHintUnlocked(false);
     setHintVisible(false);
-    setTyped("");
-  }, [index, queue, item, isCorrect, confidenceDelta, displayLevel, currentLevel, collectionID, requeueWrongCards]);
+    // Explicit as well as the hook's own reset on a changed term: a wrong last item is
+    // requeued straight after itself, and that retry asks for the same word twice running.
+    resetAnswer();
+  }, [index, queue, item, isCorrect, confidenceDelta, displayLevel, currentLevel, collectionID, requeueWrongCards, resetAnswer]);
 
   function handleConfidence(delta: -1 | 1) {
     if (confidenceDelta !== null || displayLevel === null) return;
@@ -227,7 +209,12 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
         // Keyboard has no hold gesture, so h toggles instead: press to read, press again to hide.
         if (e.key === "h" && item.hint) { e.preventDefault(); setHintUnlocked(true); setHintVisible((v) => !v); }
       }
-      if (e.code === "Enter") { e.preventDefault(); submitted ? next() : answered && submit(); }
+      // A focused button answers to Enter itself; handling it here as well would submit and
+      // then advance on a single press.
+      if (e.code === "Enter" && (e.target as HTMLElement | null)?.tagName !== "BUTTON") {
+        e.preventDefault();
+        submitted ? next() : answered && submit();
+      }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -309,28 +296,12 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
 
           {typingStep ? (
             <div className="flex flex-col gap-2">
-              <div className="relative">
-                <span aria-hidden className="absolute left-4 top-1/2 -translate-y-1/2 text-lg pointer-events-none select-none">⌨️</span>
-                <input
-                  value={typed}
-                  onChange={(e) => setTyped(e.target.value)}
-                  readOnly={submitted}
-                  placeholder="Write the answer…"
-                  aria-label="Write the answer"
-                  data-testid="type-input"
-                  autoFocus
-                  autoComplete="off"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  className={`w-full rounded-xl border pl-12 pr-4 py-3 text-left text-lg focus:outline-none placeholder:text-gray-400 dark:placeholder:text-slate-500 ${
-                    !submitted
-                      ? "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
-                      : isCorrect
-                      ? "border-green-400 dark:border-green-600 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300"
-                      : "border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300"
-                  }`}
-                />
-              </div>
+              <TypeAnswer
+                term={expected}
+                pool={pool}
+                {...answer}
+                verdict={submitted ? (isCorrect ? "right" : "wrong") : null}
+              />
               {submitted && !isCorrect && (
                 <p data-testid="type-answer" className="text-center text-sm text-gray-600 dark:text-slate-300">
                   Correct answer: <span className="font-medium">{expected}</span>
@@ -432,7 +403,7 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
                 </div>
               )}
               {!submitted && answered && (
-                <button onClick={submit} className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors">
+                <button onClick={() => submit()} className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors">
                   Confirm
                 </button>
               )}

--- a/components/TypeAnswer.tsx
+++ b/components/TypeAnswer.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { canonicalTerm, letterForBlank, nextLetterOptions, slotCount, slotsOf, type Slot } from "@/lib/typing";
+
+const OPTION_COUNT = 6; // candidates offered for the blank in hand
+// Wrong letters a card survives. Three is enough to recover from a slip or a genuinely
+// uncertain letter, and few enough that the round is still a test of knowing the word.
+const MAX_MISTAKES = 3;
+
+/**
+ * The state behind one guided answer, and the two ways it can end: the word spelled out, or
+ * the third wrong pick. Both callers keep the same rules this way, and neither has to know
+ * that a right letter and a wrong one are counted differently.
+ *
+ * `onEnd` is called during the event that ended the card, while `letters` and `mistakes` still
+ * hold their pre-update values — so the outcome is handed over rather than read back off
+ * state, and the counting stays out of the state updaters, which React may run twice.
+ */
+export function useGuidedAnswer(term: string, onEnd: (right: boolean) => void) {
+  const [letters, setLetters] = useState("");
+  const [mistakes, setMistakes] = useState(0);
+
+  // A new term is a new answer. Adjusting state during render is React's own way of resetting
+  // on a changed input, and it saves every caller from remembering to clear this by hand.
+  const [seedTerm, setSeedTerm] = useState(term);
+  if (term !== seedTerm) {
+    setSeedTerm(term);
+    setLetters("");
+    setMistakes(0);
+  }
+
+  const onChange = useCallback((next: string) => {
+    setLetters(next);
+    if ([...next].length >= slotCount(term)) onEnd(true);
+  }, [term, onEnd]);
+
+  const onMistake = useCallback(() => {
+    const spent = mistakes + 1;
+    setMistakes(spent);
+    if (spent >= MAX_MISTAKES) onEnd(false);
+  }, [mistakes, onEnd]);
+
+  const reset = useCallback(() => { setLetters(""); setMistakes(0); }, []);
+
+  return { letters, mistakes, maxMistakes: MAX_MISTAKES, onChange, onMistake, reset };
+}
+
+type Props = {
+  /** The term being spelled out; alternatives after a slash are ignored for the blanks. */
+  term: string;
+  /** Letters entered so far, in order — fixed characters are not part of this. */
+  letters: string;
+  /** Called with the answer so far each time a right letter is picked. */
+  onChange: (letters: string) => void;
+  /** Called when a wrong letter is picked, so the caller can count it against the card. */
+  onMistake: () => void;
+  /** The deck's own alphabet, which the decoy letters are drawn from. */
+  pool: string[];
+  mistakes: number;
+  maxMistakes: number;
+  /** After a verdict the answer is frozen and tinted. */
+  verdict?: "right" | "wrong" | null;
+};
+
+/**
+ * The written answer, one blank per letter, filled a letter at a time.
+ *
+ * A blank per letter says which form the card wants without giving the word away, and each
+ * blank is offered six candidates — the right letter among five decoys. A wrong pick is
+ * struck off rather than written down, so the answer on screen is only ever the real spelling
+ * and there is nothing to delete; what a wrong pick costs is one of the card's three tries.
+ */
+export default function TypeAnswer({ term, letters, onChange, onMistake, pool, mistakes, maxMistakes, verdict }: Props) {
+  const canonical = useMemo(() => canonicalTerm(term), [term]);
+  const slots = useMemo(() => slotsOf(canonical), [canonical]);
+  const typed = [...letters];
+  const position = typed.length;
+  const capacity = slots.filter((s) => s.fill).length;
+  const locked = verdict != null;
+  const done = position >= capacity;
+
+  // Letters already tried and rejected at the blank in hand. Held with the blank they belong
+  // to, so moving on clears them without an effect to keep in step.
+  const [rejected, setRejected] = useState<{ term: string; pos: number; keys: string[] }>({ term: "", pos: 0, keys: [] });
+  const struck = rejected.term === canonical && rejected.pos === position ? rejected.keys : [];
+
+  // Fresh candidates per blank, and stable for as long as the learner is on it.
+  const options = useMemo(
+    () => (locked || done ? [] : nextLetterOptions(canonical, position, pool, OPTION_COUNT)),
+    [canonical, position, pool, locked, done]
+  );
+
+  function press(key: string) {
+    if (locked || done || !options.includes(key) || struck.includes(key)) return;
+    if (key === letterForBlank(canonical, position)) {
+      onChange(letters + key);
+      return;
+    }
+    setRejected({ term: canonical, pos: position, keys: [...struck, key] });
+    onMistake();
+  }
+
+  // The offered letters answer to the physical keyboard too: this mode has no text field to
+  // focus, and a learner at a desk should not have to reach for the mouse. A key that is not
+  // one of the six does nothing at all — only a letter genuinely on offer can cost a try.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (locked || e.metaKey || e.ctrlKey || e.altKey) return;
+      const k = e.key.toLowerCase();
+      if ([...k].length === 1 && options.includes(k)) { e.preventDefault(); press(k); }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  const tint =
+    verdict === "right" ? "border-green-500 dark:border-green-500 text-green-700 dark:text-green-300"
+    : verdict === "wrong" ? "border-red-400 dark:border-red-500 text-red-700 dark:text-red-300"
+    : "border-gray-300 dark:border-slate-600 text-gray-900 dark:text-slate-100";
+
+  // Where the next letter lands, counted in slots rather than in letters so the caret skips
+  // over the spaces and hyphens that were never up for typing.
+  let seen = 0;
+  const cursor = slots.findIndex((s) => s.fill && seen++ === position);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        data-testid="type-slots"
+        role="group"
+        aria-label="Answer"
+        className="flex flex-wrap items-end justify-center gap-x-1 gap-y-2 px-2 min-h-11"
+      >
+        {slots.map((slot, i) => (
+          <SlotBox key={i} slot={slot} char={letterAt(slots, typed, i)} active={i === cursor} tint={tint} />
+        ))}
+      </div>
+
+      {/* Kept mounted while the answer is being written so the rest of the page does not jump;
+          once every blank is filled there is nothing left to choose. */}
+      <div className="flex justify-center items-center gap-1.5 min-h-11 select-none">
+        {options.map((key) => {
+          const out = struck.includes(key);
+          return (
+            <button
+              key={key}
+              type="button"
+              // The letters never take focus: with no text field in this mode, focus left
+              // sitting on a letter would make the next Enter press that letter again instead
+              // of moving on to the next card.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => press(key)}
+              disabled={out}
+              aria-label={out ? `${key}, ruled out` : key}
+              data-testid={out ? "letter-key-out" : "letter-key"}
+              className={`w-11 h-11 rounded-xl border text-lg font-medium transition-colors ${
+                out
+                  // Struck off, not removed: seeing which letters are gone is part of working
+                  // out what is left, and a vanishing key would shuffle the row mid-thought.
+                  ? "border-transparent bg-gray-50 dark:bg-slate-900 text-gray-300 dark:text-slate-700 line-through cursor-default"
+                  : "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:border-indigo-500 dark:hover:bg-indigo-900/30 active:bg-indigo-100 dark:active:bg-indigo-900/60"
+              }`}
+            >
+              {key}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* What a wrong pick costs, shown before it is spent rather than after. */}
+      <div
+        data-testid="type-tries"
+        className="flex justify-center items-center gap-1.5"
+        aria-label={`${Math.max(0, maxMistakes - mistakes)} of ${maxMistakes} tries left`}
+      >
+        {Array.from({ length: maxMistakes }, (_, i) => (
+          <span
+            key={i}
+            className={`w-2 h-2 rounded-full transition-colors ${
+              i < mistakes ? "bg-red-400 dark:bg-red-500" : "bg-gray-200 dark:bg-slate-700"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The letter sitting in slot `i`, or "" while that blank is still empty. */
+function letterAt(slots: Slot[], typed: string[], i: number): string {
+  if (!slots[i].fill) return slots[i].char;
+  let n = 0;
+  for (let j = 0; j < i; j++) if (slots[j].fill) n++;
+  return typed[n] ?? "";
+}
+
+function SlotBox({ slot, char, active, tint }: { slot: Slot; char: string; active: boolean; tint: string }) {
+  // A space is the gap between words — drawn as blank room rather than as a character, so
+  // "der Löffel" reads as two words at a glance.
+  if (!slot.fill && slot.char === " ") return <span className="w-4" />;
+  if (!slot.fill) {
+    return <span className="w-4 text-center text-lg text-gray-400 dark:text-slate-500 leading-9">{slot.char}</span>;
+  }
+  return (
+    <span
+      className={`w-7 text-center text-lg leading-8 border-b-2 transition-colors ${tint} ${
+        active ? "border-indigo-500 dark:border-indigo-400" : ""
+      }`}
+    >
+      {char || " "}
+    </span>
+  );
+}

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -371,20 +371,32 @@ test("collection list pages at 20 items", async ({ page }) => {
   await expect(page.getByText("abundant")).toHaveCount(0);
 });
 
-test("typing game: seven cards, wrong answer shows the term", async ({ page }) => {
+test("typing game: three wrong letters end the card and show the term", async ({ page }) => {
   test.setTimeout(60_000);
   await login(page);
   const id = await dictionary(page);
+  // The term is never on screen while the card is live, so the deck is read from the API to
+  // know which letters are the wrong ones to press.
+  const col = await (await page.request.get(`${API}/public/collections/${id}`)).json();
+  const termOf = new Map<string, string>(
+    (col.Cards as Array<{ Term: string; Definition: string }>).map((c) => [c.Definition, c.Term])
+  );
   await page.goto(`/collections/${id}/type`);
 
-  const input = page.getByTestId("type-input");
-  await expect(input).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("type-slots")).toBeVisible({ timeout: 30_000 });
   // A round is capped at seven cards even though the deck holds thirty.
   await expect(page.getByText("1 / 7")).toBeVisible();
 
-  await input.fill("definitely not the term");
-  await page.getByRole("button", { name: "Check" }).click();
+  const wanted = termOf.get(await page.locator("main p.text-xl").innerText())![0].toLowerCase();
+  for (let i = 1; i <= 3; i++) {
+    const offered = await page.getByTestId("letter-key").allInnerTexts();
+    const wrong = offered.find((o) => o !== wanted)!;
+    await page.getByTestId("letter-key").filter({ hasText: new RegExp(`^${wrong}$`) }).first().click();
+    // The letter is struck off rather than written down, and one of the three tries is gone.
+    await expect(page.getByTestId("type-tries")).toHaveAttribute("aria-label", `${3 - i} of 3 tries left`);
+  }
   await expect(page.getByTestId("type-answer")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("letter-key")).toHaveCount(0);
 
   await page.getByRole("button", { name: /^Next/ }).click();
   await expect(page.getByText("2 / 7")).toBeVisible();

--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -1,0 +1,37 @@
+// The spaced-repetition arithmetic, shown to a learner as the coloured level dot. The server
+// owns the real numbers; these mirror its rules so a session can show the level moving the
+// moment an answer lands, instead of a beat later when the request comes back.
+
+/** Where an answer leaves the level: up one when due, halved when wrong, 7 is mastered. */
+export function applyAnswer(level: number, correct: boolean, nextReviewAt?: string): number {
+  if (level === 7) return 7;
+  if (correct) {
+    if (level === 1) return 2;
+    if (nextReviewAt && new Date(nextReviewAt) > new Date()) return level;
+    return Math.min(level + 1, 6);
+  }
+  return Math.max(1, Math.floor(level / 2));
+}
+
+/** The learner's own "I knew that" / "not really", applied on top of the answer. */
+export function applyConfidence(level: number, delta: number): number {
+  if (delta === 1) return level >= 6 ? 7 : level + 1;
+  if (delta === -1) return Math.max(1, Math.floor(level / 2));
+  return level;
+}
+
+/** When a level falls due — the fallback date when the server's answer is not to hand. */
+export function nextReviewFromLevel(level: number): string {
+  const now = Date.now();
+  const day = 86400000;
+  const dates: Record<number, number> = {
+    1: now + day,
+    2: now + 2 * day,
+    3: now + 7 * day,
+    4: now + 14 * day,
+    5: now + 30 * day,
+    6: now + 180 * day,
+  };
+  if (level === 7) return "2099-12-31T00:00:00Z";
+  return new Date(dates[level] ?? now + day).toISOString();
+}

--- a/lib/typing.test.ts
+++ b/lib/typing.test.ts
@@ -1,31 +1,74 @@
 import { describe, it, expect } from "vitest";
-import { normalizeAnswer, isTypedCorrect } from "./typing";
+import {
+  canonicalTerm,
+  slotsOf,
+  slotCount,
+  lettersOf,
+  nextLetterOptions,
+  letterForBlank,
+  scriptOf,
+} from "./typing";
 
-describe("normalizeAnswer", () => {
-  it("levels out case, edges, repeated spaces and trailing punctuation", () => {
-    expect(normalizeAnswer("  Der   Löffel.  ")).toBe("der löffel");
-    expect(normalizeAnswer("go!")).toBe("go");
+describe("slots", () => {
+  it("draws a blank per letter and keeps the punctuation in place", () => {
+    expect(slotsOf("ad-hoc").map((s) => s.fill)).toEqual([true, true, false, true, true, true]);
+    expect(slotCount("der Löffel")).toBe(9); // the space is not typed
+  });
+
+  it("draws the first alternative when the term lists several", () => {
+    expect(canonicalTerm("der Löffel / Löffel")).toBe("der Löffel");
+    expect(slotCount("der Löffel / Löffel")).toBe(9);
   });
 });
 
-describe("isTypedCorrect", () => {
-  it("accepts the term however it was capitalised or spaced", () => {
-    expect(isTypedCorrect(" GOROUTINE ", "goroutine")).toBe(true);
+describe("letterForBlank", () => {
+  it("names the letter a blank wants, skipping the characters written in already", () => {
+    expect(letterForBlank("der Löffel", 0)).toBe("d");
+    expect(letterForBlank("der Löffel", 3)).toBe("l"); // the space is not a blank
+    expect(letterForBlank("der Löffel", 4)).toBe("ö");
+    expect(letterForBlank("der Löffel", 9)).toBeNull(); // spelled out
+  });
+});
+
+describe("nextLetterOptions", () => {
+  const pool = lettersOf(["Löffel", "Gabel", "Messer", "Küche"]);
+
+  it("always offers the letter that belongs in the blank", () => {
+    for (const [i, want] of [..."löffel"].entries()) {
+      expect(nextLetterOptions("Löffel", i, pool)).toContain(want);
+    }
   });
 
-  it("keeps accents significant — they are part of the spelling", () => {
-    expect(isTypedCorrect("Loffel", "Löffel")).toBe(false);
-    expect(isTypedCorrect("löffel", "Löffel")).toBe(true);
+  it("offers six letters when the deck can supply them", () => {
+    const opts = nextLetterOptions("Löffel", 0, pool);
+    expect(opts).toHaveLength(6);
+    expect(new Set(opts).size).toBe(6);
   });
 
-  it("accepts any alternative when the term lists them with a slash", () => {
-    const term = "der Löffel / Löffel";
-    expect(isTypedCorrect("löffel", term)).toBe(true);
-    expect(isTypedCorrect("der löffel", term)).toBe(true);
-    expect(isTypedCorrect("die gabel", term)).toBe(false);
+  it("gives the same six letters every time the same blank is asked about", () => {
+    expect(nextLetterOptions("Löffel", 2, pool)).toEqual(nextLetterOptions("Löffel", 2, pool));
+    expect(nextLetterOptions("Löffel", 2, pool)).not.toEqual(nextLetterOptions("Löffel", 3, pool));
   });
 
-  it("rejects an empty answer", () => {
-    expect(isTypedCorrect("   ", "go")).toBe(false);
+  it("counts blanks, not characters — the space in a term is never offered", () => {
+    // "der Löffel": blank 3 is the L, the space having been written in already.
+    expect(nextLetterOptions("der Löffel / Löffel", 3, pool)).toContain("l");
+    for (const o of nextLetterOptions("der Löffel / Löffel", 3, pool)) expect(o).not.toBe(" ");
+  });
+
+  it("keeps the decoys in the answer's own script — Serbian decks hold both", () => {
+    const serbian = lettersOf(["љубав", "кућа", "ljubav", "kuća"]);
+    expect(scriptOf("љ")).toBe("cyrillic");
+    for (const c of nextLetterOptions("љубав", 0, serbian)) expect(scriptOf(c)).toBe("cyrillic");
+    for (const c of nextLetterOptions("ljubav", 0, serbian)) expect(scriptOf(c)).toBe("latin");
+  });
+
+  it("offers what it can when the deck's alphabet is too thin for six", () => {
+    expect(nextLetterOptions("go", 0, lettersOf(["go", "on"]))).toEqual(expect.arrayContaining(["g"]));
+    expect(nextLetterOptions("go", 0, lettersOf(["go", "on"]))).toHaveLength(3);
+  });
+
+  it("offers nothing once every blank is filled", () => {
+    expect(nextLetterOptions("go", 2, pool)).toEqual([]);
   });
 });

--- a/lib/typing.ts
+++ b/lib/typing.ts
@@ -1,25 +1,119 @@
-// Answer checking for the typing mini-game: the learner reads a definition and writes the
-// term from memory. Pure, so the rules are testable without a keyboard.
+// The rules behind the typing mini-game: the learner reads a definition and spells the term
+// out, one letter at a time, from candidates the app offers. Pure, so the rules are testable
+// without a keyboard.
 
-// What a learner is actually being asked to recall is the word, not its punctuation or how
-// many spaces they hit. Case, surrounding whitespace, repeated spaces and trailing marks are
-// therefore levelled out before comparing — but letters are not: an accent is part of the
-// spelling in the languages this app is used for, so "Loffel" is not "Löffel".
-export function normalizeAnswer(s: string): string {
-  return s
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ")
-    .replace(/[.,;:!?]+$/, "");
+// ---------------------------------------------------------------------------
+// Guided answering: one blank per letter, filled a letter at a time from six candidates.
+//
+// Writing a term from a definition asks two questions at once — do you know the word, and
+// can you guess which of its forms the card wants ("Löffel", "der Löffel", plural?). Only
+// the first is worth testing. A blank per letter answers the second for free, and offering
+// six letters for the blank in hand removes the third unfair failure: hunting for ö on a
+// keyboard that has no ö.
+// ---------------------------------------------------------------------------
+
+const LETTER = /\p{L}/u;
+
+/**
+ * The single form a learner is asked to spell out. A card may list alternatives with a slash
+ * ("der Löffel / Löffel") and blanks can only be drawn for one of them; the first is the one
+ * the card's author led with.
+ */
+export function canonicalTerm(term: string): string {
+  const first = term.split("/")[0].trim();
+  return first || term.trim();
+}
+
+export type Slot = { char: string; fill: boolean };
+
+/**
+ * One slot per character of the answer. Letters are blanks to fill; spaces, hyphens, digits
+ * and punctuation are shown as written — they are scaffolding, not recall, and pre-filling
+ * them is what makes the blank count readable as "one word" or "article plus noun".
+ */
+export function slotsOf(term: string): Slot[] {
+  return [...canonicalTerm(term)].map((char) => ({ char, fill: LETTER.test(char) }));
+}
+
+/** How many letters a complete answer takes. */
+export function slotCount(term: string): number {
+  return slotsOf(term).filter((s) => s.fill).length;
+}
+
+/** Every distinct letter used across a set of texts — the deck's own alphabet. */
+export function lettersOf(texts: string[]): string[] {
+  const seen = new Set<string>();
+  for (const t of texts) for (const c of t.toLowerCase()) if (LETTER.test(c)) seen.add(c);
+  return [...seen].sort();
+}
+
+const SCRIPTS: Array<[string, RegExp]> = [
+  ["latin", /\p{Script=Latin}/u],
+  ["cyrillic", /\p{Script=Cyrillic}/u],
+  ["greek", /\p{Script=Greek}/u],
+];
+
+/** Which alphabet a letter belongs to — "other" for anything not worth telling apart here. */
+export function scriptOf(letter: string): string {
+  return SCRIPTS.find(([, re]) => re.test(letter))?.[0] ?? "other";
 }
 
 /**
- * Is `typed` an acceptable rendering of `term`? A term written with alternatives separated by
- * a slash ("der Löffel / Löffel") accepts any one of them — that is how such cards are
- * written, and demanding the whole string would fail a learner who knows the word.
+ * The letter that belongs in blank `position`, lowercased — what a pick is judged against.
+ * Null once the word is spelled out.
  */
-export function isTypedCorrect(typed: string, term: string): boolean {
-  const got = normalizeAnswer(typed);
-  if (got === "") return false;
-  return term.split("/").map(normalizeAnswer).filter(Boolean).includes(got);
+export function letterForBlank(term: string, position: number): string | null {
+  const blanks = slotsOf(term).filter((s) => s.fill);
+  return blanks[position]?.char.toLowerCase() ?? null;
+}
+
+/**
+ * The letters offered for the next blank: the one that belongs there plus `count - 1` decoys,
+ * shuffled. Six choices is enough to make the pick a real one while leaving no room for a
+ * typo — and because the right letter is always among them, a learner who knows the word can
+ * always finish it.
+ *
+ * Decoys are kept to the answer's own script. A Serbian deck holds the same words in both
+ * ћирилица and latinica, and a Cyrillic answer offered Latin decoys would both look broken
+ * and give itself away — only one candidate would be in the right alphabet.
+ *
+ * Deterministic in (term, position): the same blank offers the same six letters however often
+ * the page re-renders, so the choices never shuffle themselves under the learner's finger.
+ */
+export function nextLetterOptions(term: string, position: number, pool: string[], count = 6): string[] {
+  const canonical = canonicalTerm(term);
+  const target = letterForBlank(canonical, position);
+  if (!target) return [];
+  const script = scriptOf(target);
+  const rand = seeded(`${canonical}#${position}`);
+  const decoys = shuffled(pool.filter((c) => c !== target && scriptOf(c) === script), rand);
+  return shuffled([target, ...decoys.slice(0, Math.max(0, count - 1))], rand);
+}
+
+/**
+ * A small deterministic generator (mulberry32 over a string hash). The shuffle has to be
+ * stable across renders, and `Math.random` is not — nor is anything seeded off the clock.
+ */
+function seeded(seed: string): () => number {
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return () => {
+    h |= 0;
+    h = (h + 0x6d2b79f5) | 0;
+    let t = Math.imul(h ^ (h >>> 15), 1 | h);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffled<T>(items: T[], rand: () => number): T[] {
+  const a = [...items];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
 }


### PR DESCRIPTION
The typing mode asked two unfair questions alongside the one worth asking. Which of the word's forms does the card want — `Löffel`, `der Löffel`, a plural? And can your keyboard even produce `ö`? Both cost cards to people who knew the answer perfectly well.

## What it looks like now

A blank per letter, filled one letter at a time from six candidates — the right letter among five decoys. The blank count carries the form for free (`der Löffel` is nine blanks and a space), and the candidates carry the alphabet, so a missing umlaut or a phone's autocorrect can no longer lose a card.

A wrong pick is **struck off rather than written down**, and costs one of the card's **three tries**. The card then ends on its own — spelled out, or three mistakes in. There is consequently nothing left to check and nothing to delete: the Check button and backspace are both gone.

Decoys come from the deck's own alphabet and are kept to the answer's script, so a Serbian deck never offers *latinica* for a ћирилица word. They are drawn by a seeded PRNG keyed on (term, position), not `Math.random`, so a re-render never reshuffles the choices under your finger.

The type page also picks up the level dot and item badge that a blitz step already had.

## Notable

- `useGuidedAnswer` holds the rules once; the type page and the learn-mode written step both consume it.
- The verdict is handed to `finish`/`submit` explicitly rather than read back off state — the card ends in the same tick as the letter that ended it, while `letters` and `mistakes` still hold their old values.
- `applyAnswer` / `applyConfidence` / `nextReviewFromLevel` moved out of `StudySession` into `lib/progress.ts` so both call sites share one copy.
- The free-text checker (`isTypedCorrect`, `normalizeAnswer`, `composeAnswer`) is deleted along with the text input it served.

## Limits, deliberately

- **RTL scripts are not supported** — Arabic and Hebrew blanks would read backwards. Those decks need the old free-text input back as a fallback.
- A deck whose alphabet holds fewer than six letters in a script offers fewer candidates.
- Since rejected letters are struck off, a single blank can always be brute-forced inside the three tries.

## Testing

`tsc`, lint and `next build` clean; 57 unit tests and all 19 Playwright e2e pass against a local stack. The e2e typing test drives the real mechanic, reading the deck from the API to know which letters are the wrong ones to press. Checked by hand in the browser across German, French, Turkish, Serbian (both alphabets) and Greek, using the deck added in treant-dev/cram-back#27.

One bug found and fixed during review: counting a mistake inside a `setMistakes` updater is a side effect in a function React may run twice, and it sent two progress POSTs per failed card under Strict Mode. Verified as one POST per card ending, both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)