### PR TITLE
Deal the answer's own letters, shuffled

### DIFF
--- a/app/collections/[id]/type/page.tsx
+++ b/app/collections/[id]/type/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { api, Card, type ProgressEntry } from "@/lib/api";
@@ -8,7 +8,6 @@ import { isLoggedIn } from "@/lib/auth";
 import Navbar from "@/components/Navbar";
 import TypeAnswer, { useGuidedAnswer } from "@/components/TypeAnswer";
 import LevelDot from "@/components/LevelDot";
-import { lettersOf } from "@/lib/typing";
 import { applyAnswer, nextReviewFromLevel } from "@/lib/progress";
 
 const SESSION_SIZE = 7; // cards per round, matching blitz
@@ -65,10 +64,6 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
   const currentEntry = card ? (progress[card.ID] ?? null) : null;
   const currentLevel = currentEntry?.level ?? 1;
   const shownLevel = displayLevel ?? currentLevel;
-
-  // The decoys are drawn from the letters this deck actually uses, so the letters offered
-  // stay in the language being learnt.
-  const pool = useMemo(() => lettersOf(cards.map((c) => c.Term)), [cards]);
 
   // There is nothing to check: a wrong letter is never written down, so the card ends of its
   // own accord — spelled out, or three wrong picks in.
@@ -174,7 +169,7 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
         </div>
 
         <div className="self-start mx-auto mt-3 w-full max-w-lg flex flex-col gap-3">
-          <TypeAnswer term={card.Term} pool={pool} verdict={verdict} {...answer} />
+          <TypeAnswer term={card.Term} verdict={verdict} {...answer} />
 
           {/* Only shown after a wrong answer: seeing the right spelling is the whole lesson. */}
           {verdict === "wrong" && (

--- a/components/StudySession.tsx
+++ b/components/StudySession.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Navbar from "@/components/Navbar";
 import OptionButton from "@/components/OptionButton";
@@ -9,7 +9,6 @@ import SpeakButton from "@/components/SpeakButton";
 import LevelDot from "@/components/LevelDot";
 import { api, type ProgressEntry } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
-import { lettersOf } from "@/lib/typing";
 import { applyAnswer, applyConfidence, nextReviewFromLevel } from "@/lib/progress";
 import type { SessionItem } from "@/lib/session";
 
@@ -101,9 +100,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   // Only a chosen option counts as an answer to confirm: a written step ends itself, on its
   // own last letter or its third mistake.
   const answered = selected.size > 0;
-  // Decoy letters on the written step come from the letters this session's own answers use,
-  // so the alphabet offered stays that of the deck.
-  const pool = useMemo(() => lettersOf(items.map((it) => it.options.find((o) => o.isCorrect)?.text ?? "")), [items]);
 
   // `written` is the outcome of a written step, handed over by the guided answer that ended
   // it. It also stands in for `answered`: a step failed on mistakes alone ends with nothing
@@ -298,7 +294,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
             <div className="flex flex-col gap-2">
               <TypeAnswer
                 term={expected}
-                pool={pool}
                 {...answer}
                 verdict={submitted ? (isCorrect ? "right" : "wrong") : null}
               />

--- a/components/TypeAnswer.tsx
+++ b/components/TypeAnswer.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { canonicalTerm, letterForBlank, nextLetterOptions, slotCount, slotsOf, type Slot } from "@/lib/typing";
+import { canonicalTerm, letterBank, letterForBlank, slotCount, slotsOf, type Slot } from "@/lib/typing";
 
-const OPTION_COUNT = 6; // candidates offered for the blank in hand
 // Wrong letters a card survives. Three is enough to recover from a slip or a genuinely
 // uncertain letter, and few enough that the round is still a test of knowing the word.
 const MAX_MISTAKES = 3;
@@ -55,8 +54,6 @@ type Props = {
   onChange: (letters: string) => void;
   /** Called when a wrong letter is picked, so the caller can count it against the card. */
   onMistake: () => void;
-  /** The deck's own alphabet, which the decoy letters are drawn from. */
-  pool: string[];
   mistakes: number;
   maxMistakes: number;
   /** After a verdict the answer is frozen and tinted. */
@@ -66,33 +63,49 @@ type Props = {
 /**
  * The written answer, one blank per letter, filled a letter at a time.
  *
- * A blank per letter says which form the card wants without giving the word away, and each
- * blank is offered six candidates — the right letter among five decoys. A wrong pick is
- * struck off rather than written down, so the answer on screen is only ever the real spelling
- * and there is nothing to delete; what a wrong pick costs is one of the card's three tries.
+ * A blank per letter says which form the card wants without giving the word away, and the
+ * word's own letters are dealt out of order below it: the question is which letter goes
+ * where, not whether the keyboard can produce ö. A wrong pick is struck off rather than
+ * written down, so the answer on screen is only ever the real spelling and there is nothing
+ * to delete; what a wrong pick costs is one of the card's three tries.
  */
-export default function TypeAnswer({ term, letters, onChange, onMistake, pool, mistakes, maxMistakes, verdict }: Props) {
+export default function TypeAnswer({ term, letters, onChange, onMistake, mistakes, maxMistakes, verdict }: Props) {
   const canonical = useMemo(() => canonicalTerm(term), [term]);
   const slots = useMemo(() => slotsOf(canonical), [canonical]);
   const typed = [...letters];
   const position = typed.length;
-  const capacity = slots.filter((s) => s.fill).length;
+  const bank = useMemo(() => letterBank(canonical), [canonical]);
   const locked = verdict != null;
-  const done = position >= capacity;
+  const done = position >= bank.length; // one tile per blank, so the bank counts them
 
-  // Letters already tried and rejected at the blank in hand. Held with the blank they belong
-  // to, so moving on clears them without an effect to keep in step.
+  // Letters already tried and rejected at the blank in hand. Rejection is by letter, not by
+  // tile: if this blank is not an f, neither of the two f tiles will do, and spending a
+  // second try to learn that twice would be a punishment for the word having a double letter.
+  // Held with the blank they belong to, so moving on clears them without an effect to keep
+  // in step.
   const [rejected, setRejected] = useState<{ term: string; pos: number; keys: string[] }>({ term: "", pos: 0, keys: [] });
   const struck = rejected.term === canonical && rejected.pos === position ? rejected.keys : [];
 
-  // Fresh candidates per blank, and stable for as long as the learner is on it.
-  const options = useMemo(
-    () => (locked || done ? [] : nextLetterOptions(canonical, position, pool, OPTION_COUNT)),
-    [canonical, position, pool, locked, done]
-  );
+  // A tile is spent once its letter has been written down. Matched in order, so a word with
+  // two f's spends the first f tile before the second — which of the two hardly matters, but
+  // the same one must stay spent from render to render.
+  const spent = useMemo(() => {
+    const flags = bank.map(() => false);
+    for (const ch of [...letters]) {
+      const i = bank.findIndex((c, j) => !flags[j] && c === ch);
+      if (i >= 0) flags[i] = true;
+    }
+    return flags;
+  }, [bank, letters]);
 
-  function press(key: string) {
-    if (locked || done || !options.includes(key) || struck.includes(key)) return;
+  /** The tile a letter would spend next: the first of its kind still in hand. */
+  function tileFor(key: string): number {
+    return bank.findIndex((c, i) => c === key && !spent[i] && !struck.includes(c));
+  }
+
+  function press(tile: number) {
+    const key = bank[tile];
+    if (locked || done || spent[tile] || struck.includes(key)) return;
     if (key === letterForBlank(canonical, position)) {
       onChange(letters + key);
       return;
@@ -101,14 +114,16 @@ export default function TypeAnswer({ term, letters, onChange, onMistake, pool, m
     onMistake();
   }
 
-  // The offered letters answer to the physical keyboard too: this mode has no text field to
-  // focus, and a learner at a desk should not have to reach for the mouse. A key that is not
-  // one of the six does nothing at all — only a letter genuinely on offer can cost a try.
+  // The tiles answer to the physical keyboard too: this mode has no text field to focus, and
+  // a learner at a desk should not have to reach for the mouse. A key with no tile left to
+  // spend does nothing at all — only a letter genuinely on offer can cost a try.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (locked || e.metaKey || e.ctrlKey || e.altKey) return;
       const k = e.key.toLowerCase();
-      if ([...k].length === 1 && options.includes(k)) { e.preventDefault(); press(k); }
+      if ([...k].length !== 1) return;
+      const tile = tileFor(k);
+      if (tile >= 0) { e.preventDefault(); press(tile); }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -137,28 +152,32 @@ export default function TypeAnswer({ term, letters, onChange, onMistake, pool, m
         ))}
       </div>
 
-      {/* Kept mounted while the answer is being written so the rest of the page does not jump;
-          once every blank is filled there is nothing left to choose. */}
-      <div className="flex justify-center items-center gap-1.5 min-h-11 select-none">
-        {options.map((key) => {
-          const out = struck.includes(key);
+      {/* Every tile keeps its place all the way through: spent ones dim rather than vanish, so
+          the row never rearranges itself between picks. */}
+      <div className="flex flex-wrap justify-center items-center gap-1.5 min-h-11 select-none">
+        {!locked && bank.map((key, tile) => {
+          const ruledOut = struck.includes(key);
+          const used = spent[tile];
           return (
             <button
-              key={key}
+              key={tile}
               type="button"
-              // The letters never take focus: with no text field in this mode, focus left
-              // sitting on a letter would make the next Enter press that letter again instead
-              // of moving on to the next card.
+              // The tiles never take focus: with no text field in this mode, focus left sitting
+              // on a letter would make the next Enter press that letter again instead of
+              // moving on to the next card.
               onMouseDown={(e) => e.preventDefault()}
-              onClick={() => press(key)}
-              disabled={out}
-              aria-label={out ? `${key}, ruled out` : key}
-              data-testid={out ? "letter-key-out" : "letter-key"}
+              onClick={() => press(tile)}
+              disabled={used || ruledOut}
+              aria-label={used ? `${key}, used` : ruledOut ? `${key}, not this letter here` : key}
+              data-testid={used ? "letter-key-used" : ruledOut ? "letter-key-out" : "letter-key"}
               className={`w-11 h-11 rounded-xl border text-lg font-medium transition-colors ${
-                out
-                  // Struck off, not removed: seeing which letters are gone is part of working
-                  // out what is left, and a vanishing key would shuffle the row mid-thought.
-                  ? "border-transparent bg-gray-50 dark:bg-slate-900 text-gray-300 dark:text-slate-700 line-through cursor-default"
+                used
+                  ? "border-transparent bg-gray-50 dark:bg-slate-900 text-gray-300 dark:text-slate-700 cursor-default"
+                  : ruledOut
+                  // Red rather than greyed away: the letter is still in the word and will be
+                  // wanted at some later blank — it is only wrong here, which is worth
+                  // knowing and is not the same thing as being spent.
+                  ? "border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-red-500 dark:text-red-400 cursor-default"
                   : "border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:border-indigo-500 dark:hover:bg-indigo-900/30 active:bg-indigo-100 dark:active:bg-indigo-900/60"
               }`}
             >

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -387,13 +387,31 @@ test("typing game: three wrong letters end the card and show the term", async ({
   // A round is capped at seven cards even though the deck holds thirty.
   await expect(page.getByText("1 / 7")).toBeVisible();
 
-  const wanted = termOf.get(await page.locator("main p.text-xl").innerText())![0].toLowerCase();
+  const current = async () =>
+    [...termOf.get(await page.locator("main p.text-xl").innerText())!.toLowerCase()].filter((c) => /\p{L}/u.test(c));
+  const play = async (letter: string) =>
+    page.getByTestId("letter-key").filter({ hasText: new RegExp(`^${letter}$`) }).first().click();
+
+  // A wrong pick strikes off every tile of that letter at once, so three mistakes need three
+  // distinct wrong letters — and "vivid" offers only two. Spell such a card out and take the
+  // next one, rather than flake on whichever card the shuffle happens to deal first.
+  let term = await current();
+  while (new Set(term.filter((c) => c !== term[0])).size < 3) {
+    for (const ch of term) await play(ch);
+    await page.getByRole("button", { name: /^Next/ }).click();
+    term = await current();
+  }
+
+  let struck = 0;
   for (let i = 1; i <= 3; i++) {
     const offered = await page.getByTestId("letter-key").allInnerTexts();
-    const wrong = offered.find((o) => o !== wanted)!;
-    await page.getByTestId("letter-key").filter({ hasText: new RegExp(`^${wrong}$`) }).first().click();
-    // The letter is struck off rather than written down, and one of the three tries is gone.
+    const wrong = offered.find((o) => o !== term[0])!;
+    struck += offered.filter((o) => o === wrong).length;
+    await play(wrong);
     await expect(page.getByTestId("type-tries")).toHaveAttribute("aria-label", `${3 - i} of 3 tries left`);
+    // Struck off rather than written down, and every tile of that letter goes at once — none
+    // of them belongs in this blank. The tiles are gone entirely once the card has ended.
+    if (i < 3) await expect(page.getByTestId("letter-key-out")).toHaveCount(struck);
   }
   await expect(page.getByTestId("type-answer")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("letter-key")).toHaveCount(0);

--- a/lib/typing.test.ts
+++ b/lib/typing.test.ts
@@ -3,10 +3,8 @@ import {
   canonicalTerm,
   slotsOf,
   slotCount,
-  lettersOf,
-  nextLetterOptions,
+  letterBank,
   letterForBlank,
-  scriptOf,
 } from "./typing";
 
 describe("slots", () => {
@@ -30,45 +28,32 @@ describe("letterForBlank", () => {
   });
 });
 
-describe("nextLetterOptions", () => {
-  const pool = lettersOf(["Löffel", "Gabel", "Messer", "Küche"]);
+describe("letterBank", () => {
+  it("deals the answer's own letters and nothing else", () => {
+    expect([...letterBank("Löffel")].sort()).toEqual([..."effllö"].sort());
+  });
 
-  it("always offers the letter that belongs in the blank", () => {
-    for (const [i, want] of [..."löffel"].entries()) {
-      expect(nextLetterOptions("Löffel", i, pool)).toContain(want);
+  it("keeps duplicates as separate tiles — the counts are the point", () => {
+    const bank = letterBank("Löffel");
+    expect(bank).toHaveLength(6);
+    expect(bank.filter((c) => c === "f")).toHaveLength(2);
+    expect(bank.filter((c) => c === "l")).toHaveLength(2);
+  });
+
+  it("shuffles, but deals the same bank every time it is asked", () => {
+    expect(letterBank("meticulous")).toEqual(letterBank("meticulous"));
+    // A shuffle worth the name: ten letters left in written order would be a coincidence.
+    expect(letterBank("meticulous").join("")).not.toBe("meticulous");
+  });
+
+  it("deals only the form being spelled, and never the scaffolding", () => {
+    expect([...letterBank("der Löffel / Löffel")].sort()).toEqual([..."derlöffel"].sort());
+    expect(letterBank("après-midi")).not.toContain("-");
+  });
+
+  it("matches the blanks it has to fill", () => {
+    for (const term of ["der Löffel / Löffel", "l'école", "добро јутро", "ışık"]) {
+      expect(letterBank(term)).toHaveLength(slotCount(term));
     }
-  });
-
-  it("offers six letters when the deck can supply them", () => {
-    const opts = nextLetterOptions("Löffel", 0, pool);
-    expect(opts).toHaveLength(6);
-    expect(new Set(opts).size).toBe(6);
-  });
-
-  it("gives the same six letters every time the same blank is asked about", () => {
-    expect(nextLetterOptions("Löffel", 2, pool)).toEqual(nextLetterOptions("Löffel", 2, pool));
-    expect(nextLetterOptions("Löffel", 2, pool)).not.toEqual(nextLetterOptions("Löffel", 3, pool));
-  });
-
-  it("counts blanks, not characters — the space in a term is never offered", () => {
-    // "der Löffel": blank 3 is the L, the space having been written in already.
-    expect(nextLetterOptions("der Löffel / Löffel", 3, pool)).toContain("l");
-    for (const o of nextLetterOptions("der Löffel / Löffel", 3, pool)) expect(o).not.toBe(" ");
-  });
-
-  it("keeps the decoys in the answer's own script — Serbian decks hold both", () => {
-    const serbian = lettersOf(["љубав", "кућа", "ljubav", "kuća"]);
-    expect(scriptOf("љ")).toBe("cyrillic");
-    for (const c of nextLetterOptions("љубав", 0, serbian)) expect(scriptOf(c)).toBe("cyrillic");
-    for (const c of nextLetterOptions("ljubav", 0, serbian)) expect(scriptOf(c)).toBe("latin");
-  });
-
-  it("offers what it can when the deck's alphabet is too thin for six", () => {
-    expect(nextLetterOptions("go", 0, lettersOf(["go", "on"]))).toEqual(expect.arrayContaining(["g"]));
-    expect(nextLetterOptions("go", 0, lettersOf(["go", "on"]))).toHaveLength(3);
-  });
-
-  it("offers nothing once every blank is filled", () => {
-    expect(nextLetterOptions("go", 2, pool)).toEqual([]);
   });
 });

--- a/lib/typing.ts
+++ b/lib/typing.ts
@@ -1,14 +1,14 @@
 // The rules behind the typing mini-game: the learner reads a definition and spells the term
-// out, one letter at a time, from candidates the app offers. Pure, so the rules are testable
-// without a keyboard.
+// out, a letter at a time, from the word's own letters dealt out of order. Pure, so the rules
+// are testable without a keyboard.
 
 // ---------------------------------------------------------------------------
-// Guided answering: one blank per letter, filled a letter at a time from six candidates.
+// Guided answering: one blank per letter, filled from the word's own letters, shuffled.
 //
 // Writing a term from a definition asks two questions at once — do you know the word, and
 // can you guess which of its forms the card wants ("Löffel", "der Löffel", plural?). Only
-// the first is worth testing. A blank per letter answers the second for free, and offering
-// six letters for the blank in hand removes the third unfair failure: hunting for ö on a
+// the first is worth testing. A blank per letter answers the second for free, and dealing
+// the word's letters out of order removes the third unfair failure: hunting for ö on a
 // keyboard that has no ö.
 // ---------------------------------------------------------------------------
 
@@ -40,24 +40,6 @@ export function slotCount(term: string): number {
   return slotsOf(term).filter((s) => s.fill).length;
 }
 
-/** Every distinct letter used across a set of texts — the deck's own alphabet. */
-export function lettersOf(texts: string[]): string[] {
-  const seen = new Set<string>();
-  for (const t of texts) for (const c of t.toLowerCase()) if (LETTER.test(c)) seen.add(c);
-  return [...seen].sort();
-}
-
-const SCRIPTS: Array<[string, RegExp]> = [
-  ["latin", /\p{Script=Latin}/u],
-  ["cyrillic", /\p{Script=Cyrillic}/u],
-  ["greek", /\p{Script=Greek}/u],
-];
-
-/** Which alphabet a letter belongs to — "other" for anything not worth telling apart here. */
-export function scriptOf(letter: string): string {
-  return SCRIPTS.find(([, re]) => re.test(letter))?.[0] ?? "other";
-}
-
 /**
  * The letter that belongs in blank `position`, lowercased — what a pick is judged against.
  * Null once the word is spelled out.
@@ -68,26 +50,17 @@ export function letterForBlank(term: string, position: number): string | null {
 }
 
 /**
- * The letters offered for the next blank: the one that belongs there plus `count - 1` decoys,
- * shuffled. Six choices is enough to make the pick a real one while leaving no room for a
- * typo — and because the right letter is always among them, a learner who knows the word can
- * always finish it.
+ * The answer's own letters, shuffled — the tiles a learner picks from. Every letter of the
+ * word is there and nothing else, duplicates included, so "Löffel" offers two f's and two
+ * l's: the tiles carry the letter counts, which the blanks alone cannot.
  *
- * Decoys are kept to the answer's own script. A Serbian deck holds the same words in both
- * ћирилица and latinica, and a Cyrillic answer offered Latin decoys would both look broken
- * and give itself away — only one candidate would be in the right alphabet.
- *
- * Deterministic in (term, position): the same blank offers the same six letters however often
- * the page re-renders, so the choices never shuffle themselves under the learner's finger.
+ * Deterministic in the term, so the bank a card deals is the same however often the page
+ * re-renders and the tiles never rearrange themselves under the learner's finger.
  */
-export function nextLetterOptions(term: string, position: number, pool: string[], count = 6): string[] {
+export function letterBank(term: string): string[] {
   const canonical = canonicalTerm(term);
-  const target = letterForBlank(canonical, position);
-  if (!target) return [];
-  const script = scriptOf(target);
-  const rand = seeded(`${canonical}#${position}`);
-  const decoys = shuffled(pool.filter((c) => c !== target && scriptOf(c) === script), rand);
-  return shuffled([target, ...decoys.slice(0, Math.max(0, count - 1))], rand);
+  const letters = slotsOf(canonical).filter((s) => s.fill).map((s) => s.char.toLowerCase());
+  return shuffled(letters, seeded(canonical));
 }
 
 /**


### PR DESCRIPTION
Follow-up to #24, which offered six candidates per blank — the right letter among five decoys drawn from the deck's alphabet. This deals the **word's own letters** instead: all of them, shuffled, duplicates included, so `Löffel` puts two `f`s and two `l`s on the table. The tiles carry the letter counts, which the blanks alone cannot.

## A wrong pick rules out the letter, not the tile

Picking `f` at the first blank of `der Löffel` turns **both** `f` tiles red and costs one try. The colours mean different things:

- **red** — the letter is in the word, but does not go in *this* blank
- **grey** — the tile is spent, its letter already written down

Ruling out by letter also fixes a fairness bug that tile-wise striking would have shipped: a word with a double letter would have charged two tries to learn the same fact.

Spent and ruled-out tiles dim in place rather than disappearing, so the row never rearranges itself mid-thought. Three tries a card, unchanged.

## What this deletes

The whole decoy apparatus — no deck alphabet, no Latin/Cyrillic/Greek script matching, no `pool` prop and no memo building it in either caller. `lib/typing.ts` is down to six exported functions.

## Worth knowing before merging

**This changes what the mode measures.** The tiles are an anagram of the answer, so for most terms the blank count plus the letter set determines the word — the exercise is now ordering rather than recall, and the last blanks are usually free as the bank narrows. Padding the bank with a few tiles the answer never needs would buy the recall back; that is roughly ten lines on top of this, and I have not done it.

## Testing

`tsc`, lint and `next build` clean; 55 unit tests and 19/19 Playwright e2e pass. Checked by hand in the browser: `καλημέρα` dealt `μ η α λ έ α κ ρ` and spelled correctly with one progress POST, and `der Löffel` reddened both `f` tiles for a single try.

One e2e fix this forced: three mistakes now need three *distinct* wrong letters, and `vivid` offers only two — a ~3% flake depending on which card the shuffle dealt first. The test now spells such a card out and takes the next one. Ran the typing test repeatedly to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)