### PR TITLE
Cram mode, connect fixes, and the term spelled as written

### DIFF
--- a/app/collections/[id]/connect/page.tsx
+++ b/app/collections/[id]/connect/page.tsx
@@ -17,7 +17,7 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
   const [terms, setTerms] = useState<ConnectTile[]>([]);
   const [definitions, setDefinitions] = useState<ConnectTile[]>([]);
   const [connections, setConnections] = useState<Record<string, string>>({}); // termId -> defId
-  const [selectedTerm, setSelectedTerm] = useState<string | null>(null);
+  const [selected, setSelected] = useState<{ kind: "term" | "def"; id: string } | null>(null);
   const [checked, setChecked] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -45,15 +45,9 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
     setTerms(board.terms);
     setDefinitions(board.definitions);
     setConnections({});
-    setSelectedTerm(null);
+    setSelected(null);
     setChecked(false);
   }, [cards]);
-
-  const tryAgain = useCallback(() => {
-    setConnections({});
-    setSelectedTerm(null);
-    setChecked(false);
-  }, []);
 
   // Recompute line endpoints (term right-center → def left-center) after layout.
   useEffect(() => {
@@ -87,29 +81,33 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
   const isCorrectTerm = (t: ConnectTile) => { const d = connections[t.id]; return !!d && cardIdOf(d) === t.cardId; };
   const correctCount = terms.filter(isCorrectTerm).length;
 
-  function onTerm(id: string) {
+  const termOfDef = (defId: string) => Object.keys(connections).find((t) => connections[t] === defId) ?? null;
+
+  // Either column can be picked first; a click in the opposite column links the pair.
+  function onTile(kind: "term" | "def", id: string) {
     if (checked) return;
-    setSelectedTerm((prev) => (prev === id ? null : id));
-  }
-  function onDef(id: string) {
-    if (checked) return;
-    if (selectedTerm) {
+    if (selected?.kind === kind && selected.id === id) { setSelected(null); return; }
+    if (selected && selected.kind !== kind) {
+      const termId = kind === "term" ? id : selected.id;
+      const defId = kind === "def" ? id : selected.id;
       setConnections((prev) => {
         const next = { ...prev };
-        for (const t of Object.keys(next)) if (next[t] === id) delete next[t]; // a def links to one term
-        next[selectedTerm] = id;
+        delete next[termId]; // a term links to one def
+        for (const t of Object.keys(next)) if (next[t] === defId) delete next[t]; // a def links to one term
+        next[termId] = defId;
         return next;
       });
-      setSelectedTerm(null);
-    } else {
-      // no term selected → clicking a linked definition disconnects it
-      setConnections((prev) => {
-        const next = { ...prev };
-        let changed = false;
-        for (const t of Object.keys(next)) if (next[t] === id) { delete next[t]; changed = true; }
-        return changed ? next : prev;
-      });
+      setSelected(null);
+      return;
     }
+    // nothing selected in the other column → clicking a linked tile disconnects it
+    const linkedTerm = kind === "term" ? (id in connections ? id : null) : termOfDef(id);
+    if (linkedTerm) {
+      setConnections((prev) => { const next = { ...prev }; delete next[linkedTerm]; return next; });
+      setSelected(null);
+      return;
+    }
+    setSelected({ kind, id });
   }
 
   function check() {
@@ -123,15 +121,15 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
     }
   }
 
+  // Leaving is one of the two things worth doing at the foot of a board, so it sits with the
+  // other one rather than alone at the bottom of the page.
   const backLink = (
-    <div className="flex justify-center pb-10">
-      <Link
-        href={collectionID ? `/collections/${collectionID}` : "/collections"}
-        className="inline-flex items-center gap-1 text-sm font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
-      >
-        ← Back to collection
-      </Link>
-    </div>
+    <Link
+      href={collectionID ? `/collections/${collectionID}` : "/collections"}
+      className="inline-flex items-center gap-1 text-sm font-medium px-5 py-2 rounded-xl border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+    >
+      ← Back to collection
+    </Link>
   );
 
   if (error) {
@@ -174,14 +172,14 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
   const tileCls = (kind: "term" | "def", tile: ConnectTile) => {
     const connected = kind === "term" ? tile.id in connections : Object.values(connections).includes(tile.id);
     const correct = kind === "term" ? isCorrectTerm(tile) : (() => {
-      const termId = Object.keys(connections).find((t) => connections[t] === tile.id);
+      const termId = termOfDef(tile.id);
       return !!termId && cardIdOf(termId) === tile.cardId;
     })();
     const base = "min-h-12 rounded-xl border px-3 py-2 text-sm text-center break-words transition-colors select-none";
     if (checked) {
       return `${base} ${connected && correct ? "border-green-400 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300" : "border-red-400 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-300"} cursor-default`;
     }
-    if (kind === "term" && selectedTerm === tile.id) {
+    if (selected?.kind === kind && selected.id === tile.id) {
       return `${base} border-indigo-500 bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 ring-2 ring-indigo-400 cursor-pointer`;
     }
     if (connected) {
@@ -200,10 +198,9 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
             {checked
               ? <span>{correctCount} / {terms.length} correct</span>
               : <span>{connectedCount} / {terms.length} linked</span>}
-            <button onClick={restart} className="font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Restart</button>
           </div>
         </div>
-        <p className="text-xs text-gray-400 dark:text-slate-500 mb-4">Click a term, then its definition to link them.</p>
+        <p className="text-xs text-gray-400 dark:text-slate-500 mb-4">Click a term and its definition — in either order — to link them.</p>
 
         <div ref={containerRef} className="relative">
           <svg className="absolute inset-0 w-full h-full pointer-events-none z-10" data-testid="connect-lines">
@@ -220,26 +217,31 @@ export default function ConnectPage(props: PageProps<"/collections/[id]/connect"
           <div className="grid grid-cols-2 gap-x-16 gap-y-3">
             <div className="flex flex-col gap-3">
               {terms.map((t) => (
-                <button key={t.id} ref={(el) => { termRefs.current[t.id] = el; }} data-testid="connect-term" onClick={() => onTerm(t.id)} disabled={checked} className={tileCls("term", t)}>{t.text}</button>
+                <button key={t.id} ref={(el) => { termRefs.current[t.id] = el; }} data-testid="connect-term" onClick={() => onTile("term", t.id)} disabled={checked} className={tileCls("term", t)}>{t.text}</button>
               ))}
             </div>
             <div className="flex flex-col gap-3">
               {definitions.map((d) => (
-                <button key={d.id} ref={(el) => { defRefs.current[d.id] = el; }} data-testid="connect-def" onClick={() => onDef(d.id)} disabled={checked} className={tileCls("def", d)}>{d.text}</button>
+                <button key={d.id} ref={(el) => { defRefs.current[d.id] = el; }} data-testid="connect-def" onClick={() => onTile("def", d.id)} disabled={checked} className={tileCls("def", d)}>{d.text}</button>
               ))}
             </div>
           </div>
         </div>
 
-        <div className="flex justify-center mt-6">
+        {/* Leaving on the left, the one thing to press in the middle — the same footing as cram. */}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 mt-6 pb-10">
+          <div className="justify-self-start">{backLink}</div>
+          <div className="justify-self-center">
           {checked ? (
-            <button onClick={tryAgain} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 transition-colors">Try again</button>
+            // Nothing to redo: the answers are on the board. The only move left is another
+            // board, dealt from the collection the same way this one was.
+            <button onClick={restart} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 transition-colors">Go next →</button>
           ) : (
             <button onClick={check} disabled={!allConnected} className="bg-indigo-600 text-white px-5 py-2 rounded-xl font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors">Check</button>
           )}
+          </div>
         </div>
       </main>
-      {backLink}
     </div>
   );
 }

--- a/app/collections/[id]/cram/page.tsx
+++ b/app/collections/[id]/cram/page.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+import { isLoggedIn } from "@/lib/auth";
+import Navbar from "@/components/Navbar";
+import HintButton from "@/components/HintButton";
+import OptionButton from "@/components/OptionButton";
+import SpeakButton from "@/components/SpeakButton";
+import TypeAnswer, { useGuidedAnswer } from "@/components/TypeAnswer";
+import TypeInput from "@/components/TypeInput";
+import {
+  OUTCOME_EMOJI, STAGES, STAGE_LABEL, cramReducer, eligibleCards, gradeWritten,
+  initialCramState, roundSummary, roundVerdict, score, stepCard,
+} from "@/lib/cram";
+
+/**
+ * Cram: four cards drilled through four exercises — recognise the term, explain it, spell it
+ * from its own letters, write it from nothing. A card that slips falls back one exercise and
+ * waits for the retry phase, so the round ends only when every card has come all the way
+ * through. The rules live in lib/cram.ts; this page is the hands and eyes.
+ */
+export default function CramPage(props: PageProps<"/collections/[id]/cram">) {
+  const router = useRouter();
+  const [collectionID, setCollectionID] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  // Rounds are counted so the posted-once guard below can tell this card's report in this
+  // round from the same card's report in the next one.
+  const [round, setRound] = useState(0);
+  const [state, dispatch] = useReducer(cramReducer, undefined, initialCramState);
+  // The option in hand, held by position: two cards may word an answer identically, and only
+  // the one that was actually pressed should count.
+  const [selected, setSelected] = useState<number | null>(null);
+  // The written answer, held here rather than in the field: Check sits in the action row with
+  // the other verbs, where Confirm and Next are.
+  const [written, setWritten] = useState("");
+
+  // The round is drawn the way blitz draws its session — due cards first, then the ones
+  // longest unseen — and graded against the same levels, so it needs an account.
+  useEffect(() => {
+    props.params.then(({ id }) => {
+      setCollectionID(id);
+      if (!isLoggedIn()) { router.replace("/"); return null; }
+      return api.blitz.get(id);
+    }).then((res) => {
+      if (!res) return;
+      dispatch({ type: "init", cards: eligibleCards(res.items), pool: res.card_pool });
+      setLoaded(true);
+    }).catch(() => setError("Failed to load cram"));
+  }, [props.params, router]);
+
+  // Every card reports once, as it leaves the round. Posting here rather than at the end
+  // means a learner who walks away mid-round still keeps what the finished cards earned.
+  const posted = useRef(new Set<string>());
+  useEffect(() => {
+    if (state.emit.length === 0 || !collectionID) return;
+    for (const write of state.emit) {
+      const once = `${round}:${write.cardID}`;
+      if (posted.current.has(once)) continue;
+      posted.current.add(once);
+      api.progress.update(collectionID, "card", write.cardID, write.correct, 0).catch(() => {});
+    }
+    dispatch({ type: "drain" });
+  }, [state.emit, collectionID, round]);
+
+  // Another four cards, drawn the same way, without a trip back to the collection.
+  const goNext = useCallback(() => {
+    if (!collectionID) return;
+    setLoaded(false);
+    setRound((r) => r + 1);
+    setSelected(null);
+    setWritten("");
+    api.blitz.get(collectionID).then((res) => {
+      dispatch({ type: "init", cards: eligibleCards(res.items), pool: res.card_pool });
+      setLoaded(true);
+    }).catch(() => setError("Failed to load cram"));
+  }, [collectionID]);
+
+  const step = state.step;
+  const card = stepCard(state);
+  const verdict = state.verdict;
+  const isChoice = step?.stage === "recall" || step?.stage === "produce";
+
+  const advance = useCallback(() => {
+    setSelected(null);
+    setWritten("");
+    dispatch({ type: "next" });
+  }, []);
+
+  const submitWritten = useCallback(() => {
+    if (!step || verdict !== null || !written.trim()) return;
+    dispatch({ type: "answer", verdict: gradeWritten(written, step.answer) });
+  }, [step, verdict, written]);
+
+  const confirmChoice = useCallback(() => {
+    if (!step || selected === null || verdict !== null) return;
+    dispatch({ type: "answer", verdict: step.options[selected]?.isCorrect ? "right" : "wrong" });
+  }, [step, selected, verdict]);
+
+  // The letters stage ends of its own accord: spelled out, or three wrong picks in.
+  const guided = useGuidedAnswer(
+    step?.stage === "build" ? step.answer : "",
+    useCallback((right: boolean) => dispatch({ type: "answer", verdict: right ? "right" : "wrong" }), []),
+  );
+  const resetGuided = guided.reset;
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!step) return;
+      const target = e.target as HTMLElement | null;
+      if (e.key === "Enter") {
+        // A focused button answers to Enter itself, and while the written stage is unanswered
+        // the field's own form owns the key — handling either here would fire twice.
+        if (target?.tagName === "BUTTON") return;
+        if (verdict === null && target?.tagName === "INPUT") return;
+        e.preventDefault();
+        if (verdict !== null) advance();
+        else if (isChoice) confirmChoice();
+        return;
+      }
+      if (!isChoice || verdict !== null) return;
+      const num = parseInt(e.key);
+      if (num >= 1 && num <= step.options.length) { e.preventDefault(); setSelected(num - 1); }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [step, verdict, isChoice, advance, confirmChoice]);
+
+  // The hook resets itself on a changed term, but a card can be asked to spell the same word
+  // twice running once the retry phase starts, so clear it by hand as well.
+  useEffect(() => { resetGuided(); }, [state.steps, resetGuided]);
+
+  const backLink = (
+    <Link
+      href={collectionID ? `/collections/${collectionID}` : "/collections"}
+      className="inline-flex items-center gap-1 text-sm font-medium px-3 py-1.5 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors whitespace-nowrap"
+    >
+      ← Back to collection
+    </Link>
+  );
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-4">
+          <p className="text-red-500">{error}</p>
+          <button onClick={() => window.history.back()} className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline">Go back</button>
+        </div>
+      </div>
+    );
+  }
+
+  // Nothing to drill is an answer, not a wait: a collection can be all mastered, or all of
+  // its terms too long for the written stages.
+  if (loaded && state.cards.length === 0) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-4">
+          <p className="text-gray-500 dark:text-slate-400">Nothing to cram here right now.</p>
+          {backLink}
+        </div>
+      </div>
+    );
+  }
+
+  if (state.done) {
+    const total = state.cards.length;
+    const result = roundVerdict(score(state), total);
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <main className="flex-1 flex flex-col items-center justify-center gap-4 px-4 py-8">
+          <p className="text-5xl" aria-hidden>{result.emoji}</p>
+          <h2 className="text-2xl font-bold text-center">{result.title}</h2>
+          <p className="text-gray-500 dark:text-slate-400 text-lg">{score(state)} / {total} clean</p>
+
+          {/* The words again, marked: cleanly done, done the hard way, or not done at all.
+              The round is over in a couple of minutes and every card left the screen as fast
+              as it arrived — this is the only chance to see them side by side. */}
+          <ul data-testid="cram-summary" className="w-full max-w-lg flex flex-col gap-2 mt-2">
+            {roundSummary(state).map(({ card, outcome }) => (
+              <li
+                key={card.id}
+                data-testid="cram-summary-row"
+                data-outcome={outcome}
+                className="flex items-start gap-3 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3"
+              >
+                <span className="text-lg leading-6" aria-hidden>{OUTCOME_EMOJI[outcome]}</span>
+                <div className="min-w-0">
+                  <p className="font-medium text-gray-900 dark:text-slate-100 break-words">{card.term}</p>
+                  <p className="text-sm text-gray-500 dark:text-slate-400 break-words">{card.definition}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="w-full max-w-lg grid grid-cols-[1fr_auto_1fr] items-center gap-3 mt-2">
+            <div className="justify-self-start">{backLink}</div>
+            <button data-testid="cram-go-next" onClick={goNext} className="justify-self-center bg-indigo-600 text-white px-6 py-2.5 rounded-xl font-medium hover:bg-indigo-700 transition-colors">
+              Go next →
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (!step || !card) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <main className="flex-1 flex flex-col items-center justify-center px-4 gap-3 animate-pulse">
+          <div className="w-full max-w-lg h-4 bg-gray-200 dark:bg-slate-800 rounded" />
+          <div className="w-full max-w-lg min-h-48 bg-gray-100 dark:bg-slate-800 rounded-2xl" />
+          <div className="w-full max-w-lg h-10 bg-gray-100 dark:bg-slate-800 rounded-lg" />
+        </main>
+      </div>
+    );
+  }
+
+  const wrong = verdict === "wrong";
+  // The term is what most stages are asking for, so speaking it early would answer the
+  // question. It is safe once the answer is in — and at the stage that shows it as the prompt.
+  const canSpeak = step.stage === "produce" || verdict !== null;
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      {/* The same three-row grid as the flashcards and the typing game: the prompt keeps its
+          place whether or not a verdict, a hint and a keyboard are showing underneath. */}
+      <main className="flex-1 grid grid-rows-[1fr_auto_1fr] px-4">
+        <div className="self-end mx-auto mb-3 w-full max-w-lg flex items-center justify-between">
+          {/* How far in the round is, counted in exercises rather than in cards: a card is only
+              finished at the very end, so a word counter sits at zero for most of a round. */}
+          <p data-testid="cram-progress" className="text-sm text-gray-400 dark:text-slate-500">
+            Stage {STAGES.indexOf(step.stage) + 1} / {STAGES.length}
+          </p>
+          <span data-testid="cram-stage" className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-100 text-purple-600">
+            {STAGE_LABEL[step.stage]}
+          </span>
+        </div>
+
+        <div className="mx-auto w-full max-w-lg min-h-48 relative bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl shadow-sm flex flex-col items-center justify-center p-8 text-center gap-4">
+          {canSpeak && <SpeakButton text={card.term} className="absolute top-3 right-3" />}
+          {card.image && <img src={card.image} alt="" className="max-h-40 max-w-full rounded-lg object-contain" />}
+          <p data-testid="cram-prompt" className="text-xl font-medium text-gray-900 dark:text-slate-100">{step.prompt}</p>
+        </div>
+
+        <div className="self-start mx-auto mt-3 w-full max-w-lg flex flex-col gap-3">
+          {isChoice && (
+            <div className="flex flex-col gap-2">
+              {step.options.map((opt, i) => (
+                <OptionButton
+                  key={i}
+                  index={i}
+                  text={opt.text}
+                  multi={false}
+                  selected={selected === i}
+                  submitted={verdict !== null}
+                  isCorrect={opt.isCorrect}
+                  onClick={() => verdict === null && setSelected(i)}
+                />
+              ))}
+            </div>
+          )}
+
+          {step.stage === "build" && (
+            <TypeAnswer
+              term={step.answer}
+              {...guided}
+              verdict={verdict === null ? null : verdict === "wrong" ? "wrong" : "right"}
+            />
+          )}
+
+          {step.stage === "write" && (
+            <TypeInput value={written} onChange={setWritten} verdict={verdict} onSubmit={submitWritten} />
+          )}
+
+          {/* The spelling is the lesson of both written stages — shown when it was missed, and
+              when a typo was let through. */}
+          {!isChoice && wrong && (
+            <p data-testid="cram-answer" className="text-center text-sm text-gray-600 dark:text-slate-300">
+              Correct answer: <span className="font-medium">{step.answer}</span>
+            </p>
+          )}
+          {verdict === "close" && (
+            <p data-testid="cram-answer" className="text-center text-sm text-amber-600 dark:text-amber-400">
+              Close enough — it&apos;s spelled <span className="font-medium">{step.answer}</span>
+            </p>
+          )}
+
+          {/* Leaving on the left, the one thing to press in the middle: the verb sits under the
+              answer it belongs to rather than off to one side. */}
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 min-h-[44px]">
+            <div className="flex items-center gap-2 justify-self-start">
+              {backLink}
+              <HintButton key={state.steps} hint={card.hint} hotkey={isChoice} />
+            </div>
+            <div className="justify-self-center flex items-center gap-2">
+              {verdict === null && isChoice && selected !== null && (
+                <button onClick={confirmChoice} className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors">
+                  Confirm
+                </button>
+              )}
+              {verdict === null && step.stage === "write" && written.trim() && (
+                <button data-testid="cram-write-check" onClick={submitWritten} className="border border-indigo-400 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400 px-5 py-2 rounded-xl font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/30 transition-colors">
+                  Check
+                </button>
+              )}
+              {verdict !== null && (
+                <button data-testid="cram-next" onClick={advance} className="bg-indigo-600 text-white px-6 py-2.5 rounded-xl font-medium hover:bg-indigo-700 transition-colors">
+                  Next →
+                </button>
+              )}
+            </div>
+          </div>
+
+          <p className="-mt-1 text-xs text-center text-gray-400 dark:text-slate-500 hidden sm:block">
+            {verdict !== null
+              ? "Enter to continue"
+              : isChoice
+              ? `Press 1–${step.options.length} to select · Enter to confirm`
+              : "Enter to confirm"}
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/collections/[id]/page.tsx
+++ b/app/collections/[id]/page.tsx
@@ -68,10 +68,13 @@ function IconBtn({ emoji, title, onClick, danger, type = "button", form, disable
 
 // Mini-games playable over a collection's cards. Add one here and it becomes a button
 // next to Blitz — each game names itself rather than hiding behind a 🎮 menu.
-const MINI_GAMES: { emoji: string; label: string; slug: string }[] = [
+const MINI_GAMES: { emoji: string; label: string; slug: string; needsAuth?: boolean }[] = [
   { emoji: "🃏", label: "Match", slug: "match" },
   { emoji: "🔗", label: "Connect", slug: "connect" },
   { emoji: "⌨️", label: "Type", slug: "type" },
+  // Cram is drawn from the blitz queue and reports levels, so it only means anything to a
+  // signed-in learner — for anyone else the button would lead to a redirect.
+  { emoji: "🧠", label: "Cram", slug: "cram", needsAuth: true },
 ];
 
 // Form fields box (used inside CardForm/TestForm; Save/Cancel live in a side panel).
@@ -1038,6 +1041,7 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
   const hasFlip = cards.length >= 2;               // flip-card mode needs ≥2 cards
   const hasBlitz = cards.length >= 1;              // blitz is cards-only
   const hasMatch = cards.length >= 5;              // matching mini-game needs ≥5 pairs
+  const hasExercises = allExercises.length >= 1;   // worksheet session needs ≥1 exercise/quiz
   const allItemKeys = cards.map((c) => `card:${c.ID}`); // progress is card-only
   const allMastered = allItemKeys.length > 0 && allItemKeys.every((k) => itemProgress[k]?.level === 7);
 
@@ -1098,7 +1102,7 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
         )}
 
         {/* Study mode buttons + quick-add */}
-        {!editMode && (hasBlitz || isOwner || currentUserID !== null) && (
+        {!editMode && (hasBlitz || hasExercises || isOwner || currentUserID !== null) && (
           <div className="flex gap-3 mb-8 flex-wrap items-center">
             {hasBlitz && currentUserID !== null && (
               allMastered ? (
@@ -1109,7 +1113,7 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
                 </Link>
               )
             )}
-            {cards.length >= 1 && MINI_GAMES.map((g) => (
+            {cards.length >= 1 && MINI_GAMES.filter((g) => !g.needsAuth || currentUserID !== null).map((g) => (
               hasMatch ? (
                 <Link key={g.slug} href={`/collections/${collection.ID}/${g.slug}`} title={g.label} aria-label={g.label} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">
                   {g.emoji}
@@ -1123,9 +1127,11 @@ export default function CollectionPage(props: PageProps<"/collections/[id]">) {
             {hasFlip && (
               <Link href={`/collections/${collection.ID}/cards`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Cards</Link>
             )}
-            {/* No Exercise button: unanswered exercises open at the start of Blitz. Redoing an
-                answered one goes through the editor's reset, which is what clears the saved
-                answers blitz reads. */}
+            {/* Exercises also open at the start of Blitz; this button goes straight to the
+                worksheet session for collections that have any. */}
+            {hasExercises && (
+              <Link href={`/collections/${collection.ID}/exercises`} className="bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-300 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">Exercises</Link>
+            )}
             {currentUserID !== null && !isOwner && (
               <button
                 onClick={toggleFollow}

--- a/app/collections/[id]/type/page.tsx
+++ b/app/collections/[id]/type/page.tsx
@@ -8,6 +8,7 @@ import { isLoggedIn } from "@/lib/auth";
 import Navbar from "@/components/Navbar";
 import TypeAnswer, { useGuidedAnswer } from "@/components/TypeAnswer";
 import LevelDot from "@/components/LevelDot";
+import HintButton from "@/components/HintButton";
 import { applyAnswer, nextReviewFromLevel } from "@/lib/progress";
 
 const SESSION_SIZE = 7; // cards per round, matching blitz
@@ -24,10 +25,6 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
   const [score, setScore] = useState(0);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Per card, as in blitz: the first press unlocks the hint, and it is on screen only while
-  // asked for. Asking costs nothing — the term still has to be typed.
-  const [hintUnlocked, setHintUnlocked] = useState(false);
-  const [hintVisible, setHintVisible] = useState(false);
   // Where each card stands, so this mode carries the same level dot as blitz. The level shown
   // moves the moment a verdict lands and is then trued up from the server's own answer.
   const [progress, setProgress] = useState<Record<string, ProgressEntry>>({});
@@ -88,8 +85,6 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
     setVerdict(null);
     resetAnswer();
     setDisplayLevel(null);
-    setHintUnlocked(false);
-    setHintVisible(false);
     if (index + 1 >= cards.length) { setDone(true); return; }
     setIndex((i) => i + 1);
   }, [index, cards.length, resetAnswer]);
@@ -179,41 +174,9 @@ export default function TypePage(props: PageProps<"/collections/[id]/type">) {
           )}
 
           <div className="flex items-center justify-between">
-            {/* Offered, never pushed — the same bulb as blitz. No keyboard shortcut here: every
-                letter belongs to the answer being typed. */}
-            {card.Hint ? (
-              <div className="relative">
-                <button
-                  type="button"
-                  data-testid="hint-button"
-                  onClick={() => { setHintUnlocked(true); setHintVisible(true); }}
-                  onMouseEnter={() => hintUnlocked && setHintVisible(true)}
-                  onMouseLeave={() => setHintVisible(false)}
-                  onBlur={() => setHintVisible(false)}
-                  onTouchStart={(e) => { e.preventDefault(); setHintUnlocked(true); setHintVisible(true); }}
-                  onTouchEnd={() => setHintVisible(false)}
-                  onTouchCancel={() => setHintVisible(false)}
-                  onContextMenu={(e) => e.preventDefault()}
-                  aria-label="Show hint"
-                  className={`select-none text-base leading-none w-9 h-9 rounded-lg border transition-colors ${
-                    hintVisible
-                      ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
-                      : "border-gray-300 dark:border-slate-600 hover:border-amber-300 dark:hover:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20"
-                  }`}
-                >
-                  💡
-                </button>
-                {hintVisible && (
-                  <div
-                    role="tooltip"
-                    data-testid="hint-text"
-                    className="absolute top-0 left-full ml-2 z-10 w-72 max-w-[80vw] rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg px-4 py-3 text-left text-sm text-gray-600 dark:text-slate-300"
-                  >
-                    {card.Hint}
-                  </div>
-                )}
-              </div>
-            ) : <span />}
+            {/* Offered, never pushed — the same bulb as blitz. No keyboard shortcut here:
+                every letter belongs to the answer being typed. */}
+            <div className="flex items-center gap-2"><HintButton key={card.ID} hint={card.Hint} /></div>
             {/* Nothing to press until the card has ended: the letters themselves are the
                 whole interaction. */}
             {verdict === null ? <span /> : (

--- a/components/HintButton.tsx
+++ b/components/HintButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Props = {
+  /** The card's hint. Nothing is rendered when it is empty. */
+  hint: string;
+  /**
+   * Whether `h` toggles the hint. Off wherever the keyboard belongs to the answer — the
+   * bulb is still there to press.
+   */
+  hotkey?: boolean;
+};
+
+/**
+ * A hint is offered, never pushed: the first press unlocks it, and after that it is only on
+ * screen while the learner asks for it — hovering with a mouse, holding the button on a touch
+ * screen. The popup floats above its row, so revealing it never moves the question.
+ *
+ * The bulb keeps its own state and resets itself when the hint changes, so a mode only has to
+ * place it. Two cards may share a hint, so give it `key={cardID}` where that matters.
+ */
+export default function HintButton({ hint, hotkey }: Props) {
+  const [unlocked, setUnlocked] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  const [seedHint, setSeedHint] = useState(hint);
+  if (hint !== seedHint) {
+    setSeedHint(hint);
+    setUnlocked(false);
+    setVisible(false);
+  }
+
+  useEffect(() => {
+    if (!hotkey || !hint) return;
+    function onKey(e: KeyboardEvent) {
+      // Keyboard has no hold gesture, so h toggles instead: press to read, press again to hide.
+      if (e.key !== "h") return;
+      e.preventDefault();
+      setUnlocked(true);
+      setVisible((v) => !v);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [hotkey, hint]);
+
+  if (!hint) return null;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        data-testid="hint-button"
+        onClick={() => { setUnlocked(true); setVisible(true); }}
+        onMouseEnter={() => unlocked && setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onBlur={() => setVisible(false)}
+        // preventDefault keeps the tap from also firing a click, so hold-to-read and
+        // press-to-unlock stay one gesture.
+        onTouchStart={(e) => { e.preventDefault(); setUnlocked(true); setVisible(true); }}
+        onTouchEnd={() => setVisible(false)}
+        onTouchCancel={() => setVisible(false)}
+        onContextMenu={(e) => e.preventDefault()}
+        // No title: the browser's own tooltip would show up underneath our popup.
+        aria-label="Show hint"
+        className={`select-none text-base leading-none w-9 h-9 rounded-lg border transition-colors ${
+          visible
+            ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+            : "border-gray-300 dark:border-slate-600 hover:border-amber-300 dark:hover:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20"
+        }`}
+      >
+        💡
+      </button>
+      {visible && (
+        <div
+          role="tooltip"
+          data-testid="hint-text"
+          className="absolute top-0 left-full ml-2 z-10 w-72 max-w-[80vw] rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg px-4 py-3 text-left text-sm text-gray-600 dark:text-slate-300"
+        >
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/OptionButton.tsx
+++ b/components/OptionButton.tsx
@@ -40,7 +40,7 @@ export default function OptionButton({ index, text, multi, selected, submitted, 
     <div className="relative">
       <span className="absolute right-full mr-2 top-1/2 -translate-y-1/2 w-5 text-center text-xs font-mono text-gray-400 dark:text-slate-500">{index + 1}</span>
       <div className="flex flex-col gap-1">
-        <button onClick={onClick} disabled={disabled} className={containerClass()}>
+        <button data-testid="option" onClick={onClick} disabled={disabled} className={containerClass()}>
           <span className={indicatorClass()}>
             {selected && !submitted && (
               multi

--- a/components/StudySession.tsx
+++ b/components/StudySession.tsx
@@ -7,6 +7,7 @@ import OptionButton from "@/components/OptionButton";
 import TypeAnswer, { useGuidedAnswer } from "@/components/TypeAnswer";
 import SpeakButton from "@/components/SpeakButton";
 import LevelDot from "@/components/LevelDot";
+import HintButton from "@/components/HintButton";
 import { api, type ProgressEntry } from "@/lib/api";
 import { isLoggedIn } from "@/lib/auth";
 import { applyAnswer, applyConfidence, nextReviewFromLevel } from "@/lib/progress";
@@ -53,8 +54,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
   // Per item: unlocked by the first press, then shown only while asked for (hover or hold).
   // Asking for a hint costs nothing — the learner still picks the answer — so neither flag
   // is fed into scoring or into progress.
-  const [hintUnlocked, setHintUnlocked] = useState(false);
-  const [hintVisible, setHintVisible] = useState(false);
 
   // Progress state: keyed by "card:<id>" or "tq:<id>"
   const [progress, setProgress] = useState<Record<string, ProgressEntry>>({});
@@ -69,8 +68,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     setQueue(items);
     setTotal(items.length);
     setIndex(0);
-    setHintUnlocked(false);
-    setHintVisible(false);
   }
 
   useEffect(() => {
@@ -168,8 +165,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
     setSubmitted(false);
     setDisplayLevel(null);
     setConfidenceDelta(null);
-    setHintUnlocked(false);
-    setHintVisible(false);
     // Explicit as well as the hook's own reset on a changed term: a wrong last item is
     // requeued straight after itself, and that retry asks for the same word twice running.
     resetAnswer();
@@ -202,8 +197,6 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
       if (!typingStep) {
         const num = parseInt(e.key);
         if (num >= 1 && num <= item.options.length) { e.preventDefault(); toggle(item.options[num - 1].text); }
-        // Keyboard has no hold gesture, so h toggles instead: press to read, press again to hide.
-        if (e.key === "h" && item.hint) { e.preventDefault(); setHintUnlocked(true); setHintVisible((v) => !v); }
       }
       // A focused button answers to Enter itself; handling it here as well would submit and
       // then advance on a single press.
@@ -323,46 +316,7 @@ export default function StudySession({ items, collectionID, doneTitle, error, re
 
           <div className="flex items-center justify-between min-h-[44px]">
             <div className="flex items-center gap-2">
-              {/* A hint is offered, never pushed: the first press unlocks it, and after that it is
-                  only on screen while the learner asks for it — hovering with a mouse, holding the
-                  button on a touch screen. The popup floats above the row, so revealing it never
-                  moves the question or the options. */}
-              {item.hint && (
-                <div className="relative">
-                  <button
-                    type="button"
-                    data-testid="hint-button"
-                    onClick={() => { setHintUnlocked(true); setHintVisible(true); }}
-                    onMouseEnter={() => hintUnlocked && setHintVisible(true)}
-                    onMouseLeave={() => setHintVisible(false)}
-                    onBlur={() => setHintVisible(false)}
-                    // preventDefault keeps the tap from also firing a click, so hold-to-read and
-                    // press-to-unlock stay one gesture.
-                    onTouchStart={(e) => { e.preventDefault(); setHintUnlocked(true); setHintVisible(true); }}
-                    onTouchEnd={() => setHintVisible(false)}
-                    onTouchCancel={() => setHintVisible(false)}
-                    onContextMenu={(e) => e.preventDefault()}
-                    // No title: the browser's own tooltip would show up underneath our popup.
-                    aria-label="Show hint"
-                    className={`select-none text-base leading-none w-9 h-9 rounded-lg border transition-colors ${
-                      hintVisible
-                        ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
-                        : "border-gray-300 dark:border-slate-600 hover:border-amber-300 dark:hover:border-amber-700 hover:bg-amber-50 dark:hover:bg-amber-900/20"
-                    }`}
-                  >
-                    💡
-                  </button>
-                  {hintVisible && (
-                    <div
-                      role="tooltip"
-                      data-testid="hint-text"
-                      className="absolute top-0 left-full ml-2 z-10 w-72 max-w-[80vw] rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg px-4 py-3 text-left text-sm text-gray-600 dark:text-slate-300"
-                    >
-                      {item.hint}
-                    </div>
-                  )}
-                </div>
-              )}
+              <HintButton key={`${index}:${item.sourceID}`} hint={item.hint ?? ""} hotkey={!typingStep} />
             </div>
             <div className="flex items-center gap-2 ml-auto">
               {submitted && loggedIn && !item.isRetry && (

--- a/components/TypeAnswer.tsx
+++ b/components/TypeAnswer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { canonicalTerm, letterBank, letterForBlank, slotCount, slotsOf, type Slot } from "@/lib/typing";
+import { letterBank, letterForBlank, slotCount, slotsOf, type Slot } from "@/lib/typing";
 
 // Wrong letters a card survives. Three is enough to recover from a slip or a genuinely
 // uncertain letter, and few enough that the round is still a test of knowing the word.
@@ -46,7 +46,7 @@ export function useGuidedAnswer(term: string, onEnd: (right: boolean) => void) {
 }
 
 type Props = {
-  /** The term being spelled out; alternatives after a slash are ignored for the blanks. */
+  /** The term being spelled out, exactly as the card writes it. */
   term: string;
   /** Letters entered so far, in order — fixed characters are not part of this. */
   letters: string;
@@ -70,11 +70,10 @@ type Props = {
  * to delete; what a wrong pick costs is one of the card's three tries.
  */
 export default function TypeAnswer({ term, letters, onChange, onMistake, mistakes, maxMistakes, verdict }: Props) {
-  const canonical = useMemo(() => canonicalTerm(term), [term]);
-  const slots = useMemo(() => slotsOf(canonical), [canonical]);
+  const slots = useMemo(() => slotsOf(term), [term]);
   const typed = [...letters];
   const position = typed.length;
-  const bank = useMemo(() => letterBank(canonical), [canonical]);
+  const bank = useMemo(() => letterBank(term), [term]);
   const locked = verdict != null;
   const done = position >= bank.length; // one tile per blank, so the bank counts them
 
@@ -84,7 +83,7 @@ export default function TypeAnswer({ term, letters, onChange, onMistake, mistake
   // Held with the blank they belong to, so moving on clears them without an effect to keep
   // in step.
   const [rejected, setRejected] = useState<{ term: string; pos: number; keys: string[] }>({ term: "", pos: 0, keys: [] });
-  const struck = rejected.term === canonical && rejected.pos === position ? rejected.keys : [];
+  const struck = rejected.term === term && rejected.pos === position ? rejected.keys : [];
 
   // A tile is spent once its letter has been written down. Matched in order, so a word with
   // two f's spends the first f tile before the second — which of the two hardly matters, but
@@ -106,11 +105,11 @@ export default function TypeAnswer({ term, letters, onChange, onMistake, mistake
   function press(tile: number) {
     const key = bank[tile];
     if (locked || done || spent[tile] || struck.includes(key)) return;
-    if (key === letterForBlank(canonical, position)) {
+    if (key === letterForBlank(term, position)) {
       onChange(letters + key);
       return;
     }
-    setRejected({ term: canonical, pos: position, keys: [...struck, key] });
+    setRejected({ term, pos: position, keys: [...struck, key] });
     onMistake();
   }
 

--- a/components/TypeInput.tsx
+++ b/components/TypeInput.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  /** Whether the answer has been graded — after that the field is frozen and tinted. */
+  verdict: "right" | "close" | "wrong" | null;
+  /** Enter, same as pressing Check. */
+  onSubmit: () => void;
+};
+
+/**
+ * The last stage of a cram round: the word written from memory, with nothing on offer — no
+ * options, no letters. A single ruled line rather than a box, so it reads as the same kind of
+ * answer as the letter slots one stage earlier. Every browser convenience that would answer
+ * for the learner (autocorrect, spellcheck, autocapitalise) is switched off.
+ *
+ * The form is what handles Enter, rather than a window listener: a focused field is exactly
+ * where a global Enter handler would fire twice.
+ */
+export default function TypeInput({ value, onChange, verdict, onSubmit }: Props) {
+  const locked = verdict !== null;
+
+  const tint =
+    verdict === "right" ? "border-green-500 dark:border-green-500 text-green-700 dark:text-green-300"
+    : verdict === "close" ? "border-amber-400 dark:border-amber-500 text-amber-700 dark:text-amber-300"
+    : verdict === "wrong" ? "border-red-400 dark:border-red-500 text-red-700 dark:text-red-300"
+    : "border-gray-300 dark:border-slate-600 text-gray-900 dark:text-slate-100 focus:border-indigo-500 dark:focus:border-indigo-400";
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!locked && value.trim()) onSubmit();
+      }}
+    >
+      <input
+        data-testid="cram-write-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={locked}
+        autoFocus
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        spellCheck={false}
+        enterKeyHint="go"
+        aria-label="Your answer"
+        className={`w-full h-11 px-2 bg-transparent border-b-2 text-lg text-center outline-none transition-colors disabled:opacity-100 ${tint}`}
+      />
+    </form>
+  );
+}

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -480,3 +480,144 @@ test("match: a completed pair is recorded as progress", async ({ page }) => {
     expect(prog.cards[card!.ID]?.level, "matched card rose from level 1").toBe(2);
   }).toPass({ timeout: 15_000 });
 });
+
+// ── Cram ───────────────────────────────────────────────────────────────────────
+// The round is drawn from the blitz queue, so the cards it picks are not known up front;
+// every step is answered by reading the prompt and looking the answer up in the deck.
+
+type Deck = { byDefinition: Map<string, string>; byTerm: Map<string, string> };
+
+async function goBasicsDeck(page: import("@playwright/test").Page): Promise<{ id: string; deck: Deck }> {
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const go = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Go Basics");
+  expect(go, "seed collection present").toBeTruthy();
+  const detail = await (await page.request.get(`${API}/collections/${go!.ID}`)).json();
+  const cards = (detail.Cards ?? []) as Array<{ Term: string; Definition: string }>;
+  return {
+    id: go!.ID,
+    deck: {
+      byDefinition: new Map(cards.map((c) => [c.Definition, c.Term])),
+      byTerm: new Map(cards.map((c) => [c.Term, c.Definition])),
+    },
+  };
+}
+
+/** Answers the step on screen. Returns the stage it answered and the prompt it answered it to. */
+async function cramStep(page: import("@playwright/test").Page, deck: Deck, wrong = false) {
+  const stage = (await page.getByTestId("cram-stage").innerText()).trim();
+  const prompt = (await page.getByTestId("cram-prompt").innerText()).trim();
+  const term = stage === "Explain" ? prompt : deck.byDefinition.get(prompt)!;
+  expect(term, `deck knows the answer to "${prompt}"`).toBeTruthy();
+
+  if (stage === "Recognise" || stage === "Explain") {
+    const want = stage === "Explain" ? deck.byTerm.get(term)! : term;
+    const options = page.getByTestId("option");
+    const pick = wrong
+      ? options.filter({ hasNotText: exact(want) }).first()
+      : options.filter({ hasText: exact(want) }).first();
+    await pick.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+  } else if (stage === "Spell") {
+    for (const ch of [...term].filter((c) => /\p{L}/u.test(c))) {
+      await page.getByTestId("letter-key").filter({ hasText: exact(ch.toLowerCase()) }).first().click();
+    }
+  } else {
+    await page.getByTestId("cram-write-input").fill(wrong ? "zzzz" : term);
+    await page.getByTestId("cram-write-check").click();
+  }
+
+  await page.getByTestId("cram-next").click();
+  return { stage, prompt };
+}
+
+/** Plays until the done screen, answering everything right. Returns the steps it took. */
+async function playCram(page: import("@playwright/test").Page, deck: Deck, limit = 30) {
+  const trail: { stage: string; prompt: string }[] = [];
+  while (trail.length < limit && (await page.getByTestId("cram-stage").count()) > 0) {
+    trail.push(await cramStep(page, deck));
+  }
+  return trail;
+}
+
+test("cram: every card is asked at one stage before the next stage begins", async ({ page }) => {
+  test.setTimeout(90_000);
+  await login(page);
+  const { id, deck } = await goBasicsDeck(page);
+
+  await page.goto(`/collections/${id}`);
+  // The navbar logo is also called Cram, so the mini-game button is found by its aria-label.
+  await page.getByLabel("Cram").click();
+  await page.waitForURL(/\/cram$/);
+  await expect(page.getByTestId("cram-prompt")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("cram-stage")).toHaveText("Recognise");
+
+  await expect(page.getByTestId("cram-progress")).toHaveText("Stage 1 / 4");
+
+  // Answer until the round moves on: everything before that is the first stage, once per card.
+  const prompts: string[] = [];
+  while ((await page.getByTestId("cram-stage").innerText()).trim() === "Recognise" && prompts.length < 10) {
+    prompts.push((await cramStep(page, deck)).prompt);
+  }
+  expect(prompts.length, "the whole round is drilled at stage one").toBeGreaterThan(1);
+  expect(new Set(prompts).size, "every card asked once").toBe(prompts.length);
+  await expect(page.getByTestId("cram-stage")).toHaveText("Explain");
+  await expect(page.getByTestId("cram-progress")).toHaveText("Stage 2 / 4");
+});
+
+test("cram: a wrong answer brings the card back later in the round", async ({ page }) => {
+  test.setTimeout(90_000);
+  await login(page);
+  const { id, deck } = await goBasicsDeck(page);
+
+  await page.goto(`/collections/${id}/cram`);
+  await expect(page.getByTestId("cram-prompt")).toBeVisible({ timeout: 30_000 });
+  const missed = (await page.getByTestId("cram-prompt").innerText()).trim();
+  await cramStep(page, deck, true);
+
+  // Not asked again on the spot: the rest of the stage runs first.
+  await expect(page.getByTestId("cram-prompt")).not.toHaveText(missed);
+
+  const trail = await playCram(page, deck);
+  const asked = trail.filter((t) => t.stage === "Recognise" && t.prompt === missed);
+  expect(asked.length, "the failed card is asked the easiest question again").toBeGreaterThanOrEqual(1);
+});
+
+test("cram: a clean round is reported as progress", async ({ page }) => {
+  test.setTimeout(120_000);
+  await login(page);
+  const { id, deck } = await goBasicsDeck(page);
+  await page.request.delete(`${API}/collections/${id}/progress`);
+
+  await page.goto(`/collections/${id}/cram`);
+  await expect(page.getByTestId("cram-prompt")).toBeVisible({ timeout: 30_000 });
+  await playCram(page, deck);
+  await expect(page.getByText("Perfect round!")).toBeVisible({ timeout: 10_000 });
+  // The round ends on its cards, each marked with how it went.
+  const size = await page.getByTestId("cram-summary-row").count();
+  expect(size).toBeGreaterThan(1);
+  await expect(page.locator('[data-testid="cram-summary-row"][data-outcome="clean"]')).toHaveCount(size);
+
+  // Go next deals another round without leaving the page.
+  await page.getByTestId("cram-go-next").click();
+  await expect(page.getByTestId("cram-prompt")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("cram-stage")).toHaveText("Recognise");
+
+  await expect(async () => {
+    const prog = await (await page.request.get(`${API}/collections/${id}/progress`)).json();
+    const levelled = Object.values(prog.cards as Record<string, { level: number }>).filter((e) => e.level === 2);
+    expect(levelled.length).toBeGreaterThanOrEqual(size);
+  }).toPass({ timeout: 15_000 });
+});
+
+test("cram: inactive when a collection has fewer than 5 cards", async ({ page }) => {
+  test.setTimeout(60_000);
+  await login(page);
+  const cols = await (await page.request.get(`${API}/collections`)).json();
+  const pn = (cols as Array<{ ID: string; Title: string }>).find((c) => c.Title === "Private Notes");
+  expect(pn, "seed collection present").toBeTruthy();
+
+  await page.goto(`/collections/${pn!.ID}`);
+  await expect(page.getByTitle("Cram needs at least 5 cards")).toBeVisible({ timeout: 30_000 });
+  // Shown but inert: rendered as plain text, not a link.
+  await expect(page.locator('a[aria-label="Cram"]')).toHaveCount(0);
+});

--- a/lib/cram.test.ts
+++ b/lib/cram.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from "vitest";
+import type { BlitzItem, Card } from "./api";
+import {
+  MAX_OPTIONS, ROUND_SIZE, STAGES,
+  buildOptions, cramReducer, eligibleCards, finishedCount, gradeWritten,
+  initialCramState, normalizeAnswer, acceptedAnswers, roundSummary, roundVerdict, score, stepCard,
+  type CramAction, type CramCard, type CramState, type PoolEntry,
+} from "./cram";
+
+function card(p: Partial<Card>): Card {
+  return {
+    ID: "1", CollectionID: "c", Term: "term", Definition: "definition", Hint: "", Image: "",
+    Position: 0, CreatedAt: "", UpdatedAt: "", ...p,
+  } as Card;
+}
+
+const item = (p: Partial<Card>): BlitzItem => ({ type: "card", card: card(p) });
+
+/** A generator that is not the clock, so a shuffle is the same shuffle every run. */
+function seeded(seed = 1): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1103515245 + 12345) % 2147483648;
+    return s / 2147483648;
+  };
+}
+
+const cramCard = (n: number): CramCard => ({
+  id: `c${n}`, term: `term${n}`, definition: `definition ${n}`, hint: "", image: "",
+});
+
+const poolOf = (cards: CramCard[]): PoolEntry[] =>
+  cards.map((c) => ({ ID: c.id, Term: c.term, Definition: c.definition }));
+
+function start(cards: CramCard[], pool = poolOf(cards)): CramState {
+  return cramReducer(initialCramState(), { type: "init", cards, pool, rand: seeded() });
+}
+
+function apply(state: CramState, actions: CramAction[]): CramState {
+  return actions.reduce(cramReducer, state);
+}
+
+/** Plays a whole round, answering by `wrong(cardID, stage, seenSoFar)`. */
+function play(state: CramState, wrong: (cardID: string, stage: string, step: number) => boolean) {
+  const trail: { cardID: string; stage: string; right: boolean }[] = [];
+  let s = state;
+  while (!s.done && trail.length < 100) {
+    const step = s.step!;
+    const right = !wrong(step.cardID, step.stage, trail.length);
+    trail.push({ cardID: step.cardID, stage: step.stage, right });
+    s = apply(s, [{ type: "answer", verdict: right ? "right" : "wrong" }, { type: "next" }]);
+  }
+  return { state: s, trail };
+}
+
+describe("eligibleCards", () => {
+  it("keeps only cards a round can actually ask", () => {
+    const cards = eligibleCards([
+      item({ ID: "ok", Term: "goroutine", Definition: "a lightweight thread" }),
+      item({ ID: "no-term", Term: "   ", Definition: "d" }),
+      item({ ID: "no-def", Term: "t", Definition: "" }),
+      item({ ID: "letterless", Term: "42", Definition: "the answer" }),
+      item({ ID: "long", Term: "a".repeat(25), Definition: "d" }),
+      item({ ID: "edge", Term: "a".repeat(24), Definition: "d" }),
+    ]);
+    expect(cards.map((c) => c.id)).toEqual(["ok", "edge"]);
+  });
+
+  it("takes at most a round's worth", () => {
+    const many = Array.from({ length: 7 }, (_, i) => item({ ID: `c${i}`, Term: `t${i}`, Definition: `d${i}` }));
+    expect(eligibleCards(many)).toHaveLength(ROUND_SIZE);
+  });
+});
+
+describe("buildOptions", () => {
+  const round = [cramCard(1), cramCard(2)];
+  const pool = poolOf(Array.from({ length: 10 }, (_, i) => cramCard(i)));
+
+  it("offers the term among other terms, and the definition among other definitions", () => {
+    const recall = buildOptions(round[0], pool, "recall", seeded());
+    expect(recall).toHaveLength(MAX_OPTIONS);
+    expect(recall.filter((o) => o.isCorrect).map((o) => o.text)).toEqual([round[0].term]);
+    expect(recall.every((o) => o.text.startsWith("term"))).toBe(true);
+
+    const produce = buildOptions(round[0], pool, "produce", seeded());
+    expect(produce.filter((o) => o.isCorrect).map((o) => o.text)).toEqual([round[0].definition]);
+    expect(produce.every((o) => o.text.startsWith("definition"))).toBe(true);
+  });
+
+  it("draws distractors from the whole collection, not just the round", () => {
+    const options = buildOptions(round[0], pool, "recall", seeded());
+    const outsiders = options.filter((o) => !round.some((c) => c.term === o.text));
+    expect(outsiders.length).toBeGreaterThan(0);
+  });
+
+  it("never repeats a text and never runs short of a correct answer", () => {
+    const twins = [
+      { ID: "a", Term: "run", Definition: "to move fast" },
+      { ID: "b", Term: "Run", Definition: "to move fast" },
+      { ID: "c", Term: "walk", Definition: "to move slowly" },
+    ];
+    const options = buildOptions(cramCard(1), twins, "recall", seeded());
+    const keys = options.map((o) => o.text.toLowerCase());
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(options.filter((o) => o.isCorrect)).toHaveLength(1);
+  });
+
+  it("has nothing to offer at the written stages", () => {
+    expect(buildOptions(round[0], pool, "build", seeded())).toEqual([]);
+    expect(buildOptions(round[0], pool, "write", seeded())).toEqual([]);
+  });
+});
+
+describe("a clean round", () => {
+  const cards = [cramCard(1), cramCard(2), cramCard(3), cramCard(4)];
+
+  it("asks every card at one stage before moving to the next", () => {
+    const { state, trail } = play(start(cards), () => false);
+    expect(trail).toHaveLength(cards.length * STAGES.length);
+    for (const [i, stage] of STAGES.entries()) {
+      const slice = trail.slice(i * cards.length, (i + 1) * cards.length);
+      expect(slice.every((t) => t.stage === stage)).toBe(true);
+      expect(new Set(slice.map((t) => t.cardID)).size).toBe(cards.length);
+    }
+    expect(state.done).toBe(true);
+    expect(score(state)).toBe(cards.length);
+  });
+
+  it("reports every card as a plain correct answer", () => {
+    const { state } = play(start(cards), () => false);
+    expect(state.emit).toEqual(cards.map((c) => ({ cardID: c.id, correct: true })));
+  });
+});
+
+describe("a failure", () => {
+  const cards = [cramCard(1), cramCard(2), cramCard(3), cramCard(4)];
+  const failOnce = (id: string, stage: string) => {
+    let spent = false;
+    return (cardID: string, s: string) => {
+      if (cardID !== id || s !== stage || spent) return false;
+      spent = true;
+      return true;
+    };
+  };
+
+  it("drops the card back one stage, and it waits for the retry phase", () => {
+    const { trail } = play(start(cards), failOnce("c1", "write"));
+    const c1 = trail.filter((t) => t.cardID === "c1").map((t) => t.stage);
+    expect(c1).toEqual(["recall", "produce", "build", "write", "build", "write"]);
+    // The failed step is not repeated on the spot: the rest of the stage runs first.
+    const failedAt = trail.findIndex((t) => t.cardID === "c1" && !t.right);
+    expect(trail[failedAt + 1].cardID).not.toBe("c1");
+  });
+
+  it("keeps a card that fails the first stage on the first stage", () => {
+    const { trail } = play(start(cards), failOnce("c2", "recall"));
+    const c2 = trail.filter((t) => t.cardID === "c2").map((t) => t.stage);
+    expect(c2).toEqual(["recall", "recall", "produce", "build", "write"]);
+  });
+
+  it("costs the card its clean sheet but not the round", () => {
+    const { state } = play(start(cards), failOnce("c1", "build"));
+    expect(state.done).toBe(true);
+    expect(score(state)).toBe(cards.length - 1);
+    expect(finishedCount(state)).toBe(cards.length);
+  });
+});
+
+describe("progress reports", () => {
+  const cards = [cramCard(1), cramCard(2)];
+  const failWhile = (id: string, stage: string, times: number) => {
+    let left = times;
+    return (cardID: string, s: string) => {
+      if (cardID !== id || s !== stage || left <= 0) return false;
+      left--;
+      return true;
+    };
+  };
+
+  it("grades a card that failed the first stage", () => {
+    const { state } = play(start(cards), failWhile("c1", "recall", 1));
+    expect(state.emit).toContainEqual({ cardID: "c1", correct: false });
+  });
+
+  it("says nothing about a card that only faltered at a later stage", () => {
+    const { state } = play(start(cards), failWhile("c1", "build", 1));
+    expect(state.emit.map((e) => e.cardID)).toEqual(["c2"]);
+  });
+
+  it("never reports the same card twice", () => {
+    const messy = play(start(cards), failWhile("c1", "recall", 1));
+    const ids = messy.state.emit.map((e) => e.cardID);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.sort()).toEqual(["c1", "c2"]);
+  });
+
+  it("clears what the page has posted", () => {
+    const { state } = play(start(cards), () => false);
+    expect(cramReducer(state, { type: "drain" }).emit).toEqual([]);
+  });
+});
+
+describe("the safety valve", () => {
+  const cards = [cramCard(1), cramCard(2), cramCard(3), cramCard(4)];
+
+  it("drops a card out of the round on its second failure", () => {
+    const { state, trail } = play(start(cards), (cardID) => cardID === "c1");
+    expect(trail.filter((t) => t.cardID === "c1")).toHaveLength(2);
+    expect(state.done).toBe(true);
+    expect(score(state)).toBe(cards.length - 1);
+  });
+
+  it("bounds a round at 24 steps however badly it goes", () => {
+    const alwaysWrong = play(start(cards), () => true);
+    expect(alwaysWrong.trail).toHaveLength(8); // two failures each, then out
+    const worstCase = play(start(cards), (_, stage, step) => stage === "write" || step % 3 === 0);
+    expect(worstCase.trail.length).toBeLessThanOrEqual(24);
+    expect(worstCase.state.done).toBe(true);
+  });
+});
+
+describe("cramReducer guards", () => {
+  const state = start([cramCard(1), cramCard(2)]);
+
+  it("ignores a second answer while the verdict is on screen", () => {
+    const answered = cramReducer(state, { type: "answer", verdict: "wrong" });
+    const again = cramReducer(answered, { type: "answer", verdict: "wrong" });
+    expect(again).toBe(answered);
+    expect(again.cards[0].failures).toBe(1);
+  });
+
+  it("ignores a step forward before the answer is in", () => {
+    expect(cramReducer(state, { type: "next" })).toBe(state);
+  });
+
+  it("counts a tolerated typo as a pass", () => {
+    const answered = cramReducer(state, { type: "answer", verdict: "close" });
+    expect(answered.cards[0].failures).toBe(0);
+    expect(answered.cards[0].stage).toBe(1);
+  });
+
+  it("is done before it starts when nothing is eligible", () => {
+    const empty = cramReducer(initialCramState(), { type: "init", cards: [], pool: [] });
+    expect(empty.done).toBe(true);
+    expect(empty.step).toBeNull();
+  });
+});
+
+describe("roundVerdict", () => {
+  it("grades the round it was", () => {
+    expect(roundVerdict(4, 4).emoji).toBe("🎉");
+    expect(roundVerdict(3, 4).emoji).toBe("👏");
+    expect(roundVerdict(2, 4).emoji).toBe("🙂");
+    expect(roundVerdict(1, 4).emoji).toBe("💪");
+    expect(roundVerdict(0, 4).emoji).toBe("💪");
+  });
+});
+
+describe("normalizeAnswer", () => {
+  it("keeps the word and drops everything else", () => {
+    expect(normalizeAnswer("  Löffel! ")).toBe("loffel");
+    expect(normalizeAnswer("well-known")).toBe("well known");
+    expect(normalizeAnswer("a   lightweight  thread")).toBe("a lightweight thread");
+  });
+});
+
+describe("acceptedAnswers", () => {
+  it("takes either side of an alternative, and a parenthetical either way", () => {
+    expect(acceptedAnswers("lift / elevator").sort()).toEqual(["elevator", "lift"]);
+    expect(acceptedAnswers("(to) run").sort()).toEqual(["run", "to run"]);
+  });
+});
+
+describe("gradeWritten", () => {
+  it("passes the word however it was capitalised or accented", () => {
+    expect(gradeWritten("GOROUTINE", "goroutine")).toBe("right");
+    expect(gradeWritten("loffel", "Löffel")).toBe("right");
+    expect(gradeWritten("elevator", "lift / elevator")).toBe("right");
+    expect(gradeWritten("run", "(to) run")).toBe("right");
+  });
+
+  it("forgives a typo but says so", () => {
+    expect(gradeWritten("gorotine", "goroutine")).toBe("close");
+    expect(gradeWritten("goruotine", "goroutine")).toBe("close");
+  });
+
+  it("refuses a different word, and anything starting elsewhere", () => {
+    expect(gradeWritten("channel", "goroutine")).toBe("wrong");
+    expect(gradeWritten("", "goroutine")).toBe("wrong");
+    expect(gradeWritten("hun", "fun")).toBe("wrong");
+  });
+});
+
+describe("roundSummary", () => {
+  const cards = [cramCard(1), cramCard(2), cramCard(3), cramCard(4)];
+
+  it("marks every card with what became of it", () => {
+    let failedOnce = false;
+    const { state } = play(start(cards), (cardID, stage) => {
+      if (cardID === "c1") return true;                       // twice wrong → out of the round
+      if (cardID === "c2" && stage === "build" && !failedOnce) { failedOnce = true; return true; }
+      return false;
+    });
+    const summary = roundSummary(state);
+    expect(summary.map((r) => r.card.id)).toEqual(cards.map((c) => c.id));
+    expect(summary.map((r) => r.outcome)).toEqual(["failed", "shaky", "clean", "clean"]);
+    expect(summary[0].card.term).toBe("term1");
+    expect(summary[0].card.definition).toBe("definition 1");
+  });
+});
+
+describe("buildOptions with little to hide the answer among", () => {
+  it("offers what there is rather than padding the list", () => {
+    const only = [{ ID: "other", Term: "walk", Definition: "to move slowly" }];
+    const two = buildOptions(cramCard(1), only, "recall", seeded());
+    expect(two).toHaveLength(2);
+    expect(two.filter((o) => o.isCorrect)).toHaveLength(1);
+
+    const alone = buildOptions(cramCard(1), [], "recall", seeded());
+    expect(alone.map((o) => o.text)).toEqual([cramCard(1).term]);
+  });
+});
+
+describe("stepCard", () => {
+  it("hands back the card the live step belongs to", () => {
+    const state = start([cramCard(1), cramCard(2)]);
+    expect(stepCard(state)?.id).toBe(state.step!.cardID);
+    expect(stepCard(initialCramState())).toBeNull();
+  });
+});
+
+describe("eligibleCards carries the card over whole", () => {
+  it("keeps the hint and the image, and honours a smaller round", () => {
+    const cards = eligibleCards([
+      item({ ID: "a", Term: "goroutine", Definition: "a thread", Hint: "think green", Image: "pic.png" }),
+      item({ ID: "b", Term: "channel", Definition: "a pipe" }),
+    ], 1);
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toEqual({ id: "a", term: "goroutine", definition: "a thread", hint: "think green", image: "pic.png" });
+  });
+});
+
+describe("roundVerdict on a short round", () => {
+  it("reads the score against the round that was actually played", () => {
+    expect(roundVerdict(2, 2).emoji).toBe("\u{1F389}");
+    expect(roundVerdict(1, 2).emoji).toBe("\u{1F44F}");
+    expect(roundVerdict(0, 2).emoji).toBe("\u{1F4AA}");
+    expect(roundVerdict(0, 0).emoji).toBe("\u{1F44F}");
+  });
+});
+
+describe("gradeWritten scales its patience with the word", () => {
+  it("forgives two slips in a long word but only one in a short one", () => {
+    expect(gradeWritten("dilligennt", "diligent")).toBe("close");   // 8 letters, two edits
+    expect(gradeWritten("dilligennts", "diligent")).toBe("wrong");  // three edits
+    expect(gradeWritten("fesable", "feasible")).toBe("close");
+    expect(gradeWritten("cnie", "concise")).toBe("wrong");
+  });
+
+  it("reads spacing, case and punctuation as the same answer", () => {
+    expect(gradeWritten("  Well—Known  ", "well known")).toBe("right");
+    expect(gradeWritten("no longer used; out of date", "No longer used; out of date")).toBe("right");
+  });
+});

--- a/lib/cram.ts
+++ b/lib/cram.ts
@@ -1,0 +1,418 @@
+// The rules behind cram: four cards drilled through four exercises of rising difficulty, and
+// a card that slips falls back an exercise rather than being waved through. Pure, so a round
+// can be played out in a test without a browser.
+//
+// The shape of a round comes from what each stage actually asks. Recognising a term among
+// four is the easiest thing a card can be asked (it is what blitz asks), writing it from
+// memory with no letters offered is the hardest, and the two in between step from one to the
+// other. Falling back one stage on a failure is the whole idea: the answer was just shown, so
+// repeating the *same* exercise would test nothing, while the exercise below it is now
+// answerable and worth the repetition.
+
+import type { BlitzItem } from "./api";
+import { slotCount } from "./typing";
+
+export type Stage = "recall" | "produce" | "build" | "write";
+
+export const STAGES: readonly Stage[] = ["recall", "produce", "build", "write"];
+
+/** Cards per round. Small enough that the four stages stay one sitting. */
+export const ROUND_SIZE = 4;
+
+/** Options per multiple-choice stage, matching blitz. */
+export const MAX_OPTIONS = 4;
+
+/**
+ * The longest term the round will take on. Past two dozen letters the letter bank stops being
+ * a puzzle and becomes clerical work, and the same term typed out is worse — so rather than
+ * quietly dropping stages for long cards and leaving a round where some cards were asked
+ * less than others, such a card sits the round out entirely.
+ */
+export const MAX_TERM_LETTERS = 24;
+
+/**
+ * Failures a card is allowed per round. On the second one it is shown its answer and leaves
+ * the round: an unlearnable card would otherwise keep falling back and climbing again, and a
+ * round that cannot end is worse for the learner than one card left unlearned. With this cap
+ * a round is at most 24 steps against 16 for a clean one.
+ */
+export const MAX_FAILURES = 2;
+
+/** How far off a written answer may be and still pass, by length of the expected answer. */
+const TYPO_ALLOWANCE = (length: number) => (length <= 7 ? 1 : 2);
+
+export type CramCard = {
+  id: string;
+  term: string;
+  definition: string;
+  hint: string;
+  image: string;
+};
+
+export type CramOption = { text: string; isCorrect: boolean };
+
+/** One thing asked of one card: what is shown, what answers it, and what to pick from. */
+export type CramStep = {
+  cardID: string;
+  stage: Stage;
+  prompt: string;
+  answer: string;
+  options: CramOption[]; // multiple-choice stages only; empty for build and write
+};
+
+export type Verdict = "right" | "close" | "wrong";
+
+/** A single progress report, drained by the page and posted once. */
+export type ProgressWrite = { cardID: string; correct: boolean };
+
+export type PoolEntry = { ID: string; Term: string; Definition: string };
+
+type CardState = {
+  card: CramCard;
+  /** Index into STAGES; equal to STAGES.length once the card has cleared the round. */
+  stage: number;
+  failures: number;
+  /** Failed the easiest stage — the one blitz also grades. */
+  recallFailed: boolean;
+  /** Cleared or dropped: out of the round either way. */
+  out: boolean;
+  cleared: boolean;
+  /** The pass and stage this card was last asked at, so one pass never asks it twice over. */
+  servedPass: number;
+  servedStage: number;
+};
+
+export type CramState = {
+  cards: CardState[];
+  pool: PoolEntry[];
+  rand: () => number;
+  /** Passes over the round; the first is the straight run, the rest are the retry phase. */
+  pass: number;
+  stageCursor: number;
+  step: CramStep | null;
+  verdict: Verdict | null;
+  /** Progress reports waiting to be posted. */
+  emit: ProgressWrite[];
+  steps: number;
+  done: boolean;
+};
+
+export type CramAction =
+  | { type: "init"; cards: CramCard[]; pool: PoolEntry[]; rand?: () => number }
+  | { type: "answer"; verdict: Verdict }
+  | { type: "next" }
+  | { type: "drain" };
+
+export function initialCramState(): CramState {
+  return {
+    cards: [], pool: [], rand: Math.random, pass: 0, stageCursor: 0,
+    step: null, verdict: null, emit: [], steps: 0, done: false,
+  };
+}
+
+/**
+ * The cards of a blitz answer that cram can actually drill. A term with no letters at all
+ * ("42") would deal an empty letter bank, which the build stage cannot end — so it is not a
+ * matter of taste but of the round being finishable.
+ */
+export function eligibleCards(items: BlitzItem[], limit = ROUND_SIZE): CramCard[] {
+  return items
+    .filter((i): i is Extract<BlitzItem, { type: "card" }> => i.type === "card")
+    .map((i) => i.card)
+    .filter((c) => {
+      if (!c.Term.trim() || !c.Definition.trim()) return false;
+      const letters = slotCount(c.Term);
+      return letters > 0 && letters <= MAX_TERM_LETTERS;
+    })
+    .slice(0, limit)
+    .map((c) => ({
+      id: c.ID,
+      term: c.Term,
+      definition: c.Definition,
+      hint: c.Hint ?? "",
+      image: c.Image ?? "",
+    }));
+}
+
+function shuffle<T>(items: T[], rand: () => number): T[] {
+  const a = [...items];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+const dedupeKey = (text: string) => text.trim().toLowerCase();
+
+/**
+ * The options for a multiple-choice stage: the answer plus distractors drawn from the whole
+ * collection, not just the four cards in hand — a round of one card would otherwise have
+ * nothing to hide the answer among.
+ */
+export function buildOptions(card: CramCard, pool: PoolEntry[], stage: Stage, rand: () => number = Math.random): CramOption[] {
+  if (stage !== "recall" && stage !== "produce") return [];
+  const correct = stage === "recall" ? card.term : card.definition;
+  const seen = new Set([dedupeKey(correct)]);
+  const distractors = shuffle(pool.filter((c) => c.ID !== card.id), rand)
+    .map((c) => (stage === "recall" ? c.Term : c.Definition))
+    .filter((t) => {
+      const key = dedupeKey(t ?? "");
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, MAX_OPTIONS - 1);
+  return shuffle([...distractors, correct], rand).map((text) => ({ text, isCorrect: text === correct }));
+}
+
+function stepFor(card: CramCard, stage: Stage, pool: PoolEntry[], rand: () => number): CramStep {
+  const askDefinition = stage === "produce";
+  return {
+    cardID: card.id,
+    stage,
+    prompt: askDefinition ? card.term : card.definition,
+    answer: askDefinition ? card.definition : card.term,
+    options: buildOptions(card, pool, stage, rand),
+  };
+}
+
+/**
+ * The next card to ask and what to ask it. A pass walks the stages in order and asks every
+ * card sitting at the stage in hand; a card that just passed one stage is picked up again at
+ * the next, which is what makes the first pass a straight run through all four. A card that
+ * failed has fallen behind the stage cursor, so it waits for the next pass — the retry phase.
+ */
+function pick(cards: CardState[], pass: number, fromStage: number): { index: number; stage: number } | null {
+  for (let s = fromStage; s < STAGES.length; s++) {
+    const index = cards.findIndex(
+      (c) => !c.out && c.stage === s && !(c.servedPass === pass && c.servedStage === s)
+    );
+    if (index >= 0) return { index, stage: s };
+  }
+  return null;
+}
+
+function serveNext(state: CramState): CramState {
+  let pass = state.pass;
+  let found = pick(state.cards, pass, state.stageCursor);
+  if (!found) {
+    // The pass is spent. Anything still in the round starts the next one from its own stage.
+    pass += 1;
+    found = pick(state.cards, pass, 0);
+  }
+  if (!found) return { ...state, step: null, verdict: null, done: true };
+
+  const cards = state.cards.map((c, i) =>
+    i === found.index ? { ...c, servedPass: pass, servedStage: found.stage } : c
+  );
+  return {
+    ...state,
+    cards,
+    pass,
+    stageCursor: found.stage,
+    step: stepFor(cards[found.index].card, STAGES[found.stage], state.pool, state.rand),
+    verdict: null,
+    steps: state.steps + 1,
+  };
+}
+
+export function cramReducer(state: CramState, action: CramAction): CramState {
+  switch (action.type) {
+    case "init": {
+      const rand = action.rand ?? Math.random;
+      const cards: CardState[] = action.cards.map((card) => ({
+        card, stage: 0, failures: 0, recallFailed: false, out: false, cleared: false,
+        servedPass: -1, servedStage: -1,
+      }));
+      const seeded: CramState = {
+        ...initialCramState(), cards, pool: action.pool, rand,
+        done: cards.length === 0,
+      };
+      return cards.length === 0 ? seeded : serveNext(seeded);
+    }
+
+    case "answer": {
+      // A verdict already on screen means this is a second press of the same answer — a
+      // double click, or Enter held down. Counting it twice would cost the card a life it
+      // never lost.
+      if (!state.step || state.verdict !== null) return state;
+      const correct = action.verdict !== "wrong";
+      const index = state.cards.findIndex((c) => c.card.id === state.step!.cardID);
+      if (index < 0) return state;
+
+      const before = state.cards[index];
+      let after: CardState;
+      if (correct) {
+        const stage = before.stage + 1;
+        after = { ...before, stage, cleared: stage >= STAGES.length, out: stage >= STAGES.length };
+      } else {
+        const failures = before.failures + 1;
+        after = {
+          ...before,
+          failures,
+          // Only the first stage is graded, and only when it is the card's first failure:
+          // that is the same question blitz asks, so it is the one the level scale knows how
+          // to read.
+          recallFailed: before.recallFailed || (before.stage === 0 && before.failures === 0),
+          stage: Math.max(0, before.stage - 1),
+          out: failures >= MAX_FAILURES,
+        };
+      }
+
+      const cards = state.cards.map((c, i) => (i === index ? after : c));
+      const write = after.out ? progressWrite(after) : null;
+      return {
+        ...state,
+        cards,
+        verdict: action.verdict,
+        emit: write ? [...state.emit, write] : state.emit,
+      };
+    }
+
+    case "next":
+      if (!state.step || state.verdict === null) return state;
+      return serveNext(state);
+
+    case "drain":
+      return state.emit.length === 0 ? state : { ...state, emit: [] };
+  }
+}
+
+/**
+ * What a finished card is worth as spaced repetition. A clean round is an ordinary correct
+ * answer — cram plays by the same due-date rule as every other mode. Failing the easiest
+ * stage is the same failure blitz grades, so it carries the same penalty. Failing only the
+ * harder stages is real information, but not information the level scale has words for: the
+ * card was recognised and only faltered on being produced, so it is left alone.
+ */
+function progressWrite(card: CardState): ProgressWrite | null {
+  if (card.failures === 0) return { cardID: card.card.id, correct: true };
+  if (card.recallFailed) return { cardID: card.card.id, correct: false };
+  return null;
+}
+
+/** The card the live step belongs to — its hint, image and term. */
+export function stepCard(state: CramState): CramCard | null {
+  if (!state.step) return null;
+  return state.cards.find((c) => c.card.id === state.step!.cardID)?.card ?? null;
+}
+
+/** How a card came out of the round, for the summary the done screen shows. */
+export type Outcome = "clean" | "shaky" | "failed";
+
+export const OUTCOME_EMOJI: Record<Outcome, string> = {
+  clean: "\u2705",
+  shaky: "\u{1F33B}",
+  failed: "\u274C",
+};
+
+/**
+ * Every card of the round with what became of it, in the order they were drawn. A round is
+ * over in a minute or two and the cards are gone from the screen as fast as they came, so the
+ * last thing it shows is the four words again — with the ones that need another look marked.
+ */
+export function roundSummary(state: CramState): { card: CramCard; outcome: Outcome }[] {
+  return state.cards.map((c) => ({
+    card: c.card,
+    outcome: !c.cleared ? "failed" : c.failures === 0 ? "clean" : "shaky",
+  }));
+}
+
+/** Cards that finished the round without a single slip. */
+export function score(state: CramState): number {
+  return state.cards.filter((c) => c.cleared && c.failures === 0).length;
+}
+
+/** How many cards are out of the round, for the progress line. */
+export function finishedCount(state: CramState): number {
+  return state.cards.filter((c) => c.out).length;
+}
+
+export const STAGE_LABEL: Record<Stage, string> = {
+  recall: "Recognise",
+  produce: "Explain",
+  build: "Spell",
+  write: "Write",
+};
+
+/** The done screen's headline: the same round reads differently at 4 out of 4 and at 1. */
+export function roundVerdict(score: number, total: number): { emoji: string; title: string } {
+  if (total > 0 && score >= total) return { emoji: "🎉", title: "Perfect round!" };
+  if (score >= total - 1) return { emoji: "👏", title: "Nicely done" };
+  if (score * 2 >= total) return { emoji: "🙂", title: "Solid work" };
+  return { emoji: "💪", title: "Next time you'll get it" };
+}
+
+// ---------------------------------------------------------------------------
+// Grading the written stage
+// ---------------------------------------------------------------------------
+
+/**
+ * A written answer stripped of everything that is not the word: case, accents, punctuation
+ * and the difference between a hyphen and a space. What is left is what the learner meant.
+ */
+export function normalizeAnswer(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/[.,;:!?"'’`]/g, "")
+    .replace(/[-–—]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Every spelling a card would accept: alternatives written as "lift / elevator" are each an
+ * answer on their own, and a parenthetical is optional — "(to) run" is answered by "to run"
+ * and by "run".
+ */
+export function acceptedAnswers(term: string): string[] {
+  const out = new Set<string>();
+  for (const part of term.split(/[/|]/)) {
+    const withParens = part.replace(/[()]/g, " ");
+    const withoutParens = part.replace(/\([^)]*\)/g, " ");
+    for (const variant of [withParens, withoutParens]) {
+      const key = normalizeAnswer(variant);
+      if (key) out.add(key);
+    }
+  }
+  return [...out];
+}
+
+/** Optimal string alignment distance — insertions, deletions, substitutions, transpositions. */
+function editDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const d: number[][] = Array.from({ length: rows }, (_, i) => [i, ...Array(cols - 1).fill(0)]);
+  for (let j = 0; j < cols; j++) d[0][j] = j;
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      d[i][j] = Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + cost);
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
+      }
+    }
+  }
+  return d[rows - 1][cols - 1];
+}
+
+/**
+ * The written stage grades recall, not orthography — the stage before it already had the
+ * learner place every letter. So a typo passes, and is told about; a different word does not.
+ * The first letter has to be right either way: it is the one part of a word nobody mistypes
+ * while knowing it, and requiring it keeps "channel" from passing for "chancel".
+ */
+export function gradeWritten(input: string, term: string): Verdict {
+  const got = normalizeAnswer(input);
+  if (!got) return "wrong";
+  const accepted = acceptedAnswers(term);
+  if (accepted.includes(got)) return "right";
+  for (const want of accepted) {
+    if (want[0] !== got[0]) continue;
+    if (editDistance(want, got) <= TYPO_ALLOWANCE(want.length)) return "close";
+  }
+  return "wrong";
+}

--- a/lib/progress.test.ts
+++ b/lib/progress.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { applyAnswer, applyConfidence, nextReviewFromLevel } from "./progress";
+
+// These mirror the server's own arithmetic (cram-back internal/service: progressApplyAnswer,
+// progressApplyConfidence, progressNextReview). A session shows the level moving the moment an
+// answer lands, so a drift between the two would be visible as a number that jumps back when
+// the request returns.
+
+const inFuture = new Date(Date.now() + 86400000).toISOString();
+const inPast = new Date(Date.now() - 86400000).toISOString();
+
+describe("applyAnswer", () => {
+  it("leaves a mastered card alone, right or wrong", () => {
+    expect(applyAnswer(7, true)).toBe(7);
+    expect(applyAnswer(7, false)).toBe(7);
+  });
+
+  it("always moves a brand new card off level 1", () => {
+    expect(applyAnswer(1, true, inFuture)).toBe(2);
+  });
+
+  it("does not stack answers given before the card falls due", () => {
+    expect(applyAnswer(3, true, inFuture)).toBe(3);
+    expect(applyAnswer(5, true, inFuture)).toBe(5);
+  });
+
+  it("raises a due card by one, and stops short of mastery", () => {
+    expect(applyAnswer(3, true, inPast)).toBe(4);
+    expect(applyAnswer(6, true, inPast)).toBe(6);
+    expect(applyAnswer(4, true)).toBe(5);
+  });
+
+  it("halves a wrong answer whether or not it was due", () => {
+    expect(applyAnswer(6, false, inFuture)).toBe(3);
+    expect(applyAnswer(3, false, inPast)).toBe(1);
+    expect(applyAnswer(1, false)).toBe(1);
+  });
+});
+
+describe("applyConfidence", () => {
+  it("is the only way to reach mastery", () => {
+    expect(applyConfidence(6, 1)).toBe(7);
+    expect(applyConfidence(7, 1)).toBe(7);
+    expect(applyConfidence(4, 1)).toBe(5);
+  });
+
+  it("halves on a lowered confidence, and floors at 1", () => {
+    expect(applyConfidence(5, -1)).toBe(2);
+    expect(applyConfidence(1, -1)).toBe(1);
+  });
+
+  it("changes nothing without an opinion", () => {
+    expect(applyConfidence(4, 0)).toBe(4);
+  });
+});
+
+describe("nextReviewFromLevel", () => {
+  it("spaces reviews further apart the better a card is known", () => {
+    const days = (level: number) =>
+      Math.round((new Date(nextReviewFromLevel(level)).getTime() - Date.now()) / 86400000);
+    expect(days(1)).toBe(1);
+    expect(days(2)).toBe(2);
+    expect(days(3)).toBe(7);
+    expect(days(4)).toBe(14);
+    expect(days(5)).toBe(30);
+    expect(days(6)).toBe(180);
+  });
+
+  it("puts a mastered card out of reach rather than in a queue", () => {
+    expect(nextReviewFromLevel(7)).toBe("2099-12-31T00:00:00Z");
+  });
+
+  it("falls back to a day for a level it does not know", () => {
+    const days = (new Date(nextReviewFromLevel(0)).getTime() - Date.now()) / 86400000;
+    expect(Math.round(days)).toBe(1);
+  });
+});

--- a/lib/typing.test.ts
+++ b/lib/typing.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  canonicalTerm,
   slotsOf,
   slotCount,
   letterBank,
@@ -13,9 +12,9 @@ describe("slots", () => {
     expect(slotCount("der Löffel")).toBe(9); // the space is not typed
   });
 
-  it("draws the first alternative when the term lists several", () => {
-    expect(canonicalTerm("der Löffel / Löffel")).toBe("der Löffel");
-    expect(slotCount("der Löffel / Löffel")).toBe(9);
+  it("spells the term as written, slash and all", () => {
+    expect(slotCount("be/get bogged down")).toBe(15); // two spaces and the slash are not typed
+    expect(slotsOf("be/get")[2]).toEqual({ char: "/", fill: false });
   });
 });
 
@@ -46,13 +45,13 @@ describe("letterBank", () => {
     expect(letterBank("meticulous").join("")).not.toBe("meticulous");
   });
 
-  it("deals only the form being spelled, and never the scaffolding", () => {
-    expect([...letterBank("der Löffel / Löffel")].sort()).toEqual([..."derlöffel"].sort());
+  it("deals the letters and never the scaffolding", () => {
+    expect([...letterBank("be/get")].sort()).toEqual([..."beget"].sort());
     expect(letterBank("après-midi")).not.toContain("-");
   });
 
   it("matches the blanks it has to fill", () => {
-    for (const term of ["der Löffel / Löffel", "l'école", "добро јутро", "ışık"]) {
+    for (const term of ["be/get bogged down", "l'école", "добро јутро", "ışık"]) {
       expect(letterBank(term)).toHaveLength(slotCount(term));
     }
   });

--- a/lib/typing.ts
+++ b/lib/typing.ts
@@ -14,25 +14,16 @@
 
 const LETTER = /\p{L}/u;
 
-/**
- * The single form a learner is asked to spell out. A card may list alternatives with a slash
- * ("der Löffel / Löffel") and blanks can only be drawn for one of them; the first is the one
- * the card's author led with.
- */
-export function canonicalTerm(term: string): string {
-  const first = term.split("/")[0].trim();
-  return first || term.trim();
-}
-
 export type Slot = { char: string; fill: boolean };
 
 /**
- * One slot per character of the answer. Letters are blanks to fill; spaces, hyphens, digits
- * and punctuation are shown as written — they are scaffolding, not recall, and pre-filling
- * them is what makes the blank count readable as "one word" or "article plus noun".
+ * One slot per character of the answer, the term exactly as the card writes it. Letters are
+ * blanks to fill; spaces, slashes, hyphens, digits and punctuation are shown as written —
+ * they are scaffolding, not recall, and pre-filling them is what makes the blank count
+ * readable as "one word" or "article plus noun".
  */
 export function slotsOf(term: string): Slot[] {
-  return [...canonicalTerm(term)].map((char) => ({ char, fill: LETTER.test(char) }));
+  return [...term].map((char) => ({ char, fill: LETTER.test(char) }));
 }
 
 /** How many letters a complete answer takes. */
@@ -58,9 +49,8 @@ export function letterForBlank(term: string, position: number): string | null {
  * re-renders and the tiles never rearrange themselves under the learner's finger.
  */
 export function letterBank(term: string): string[] {
-  const canonical = canonicalTerm(term);
-  const letters = slotsOf(canonical).filter((s) => s.fill).map((s) => s.char.toLowerCase());
-  return shuffled(letters, seeded(canonical));
+  const letters = slotsOf(term).filter((s) => s.fill).map((s) => s.char.toLowerCase());
+  return shuffled(letters, seeded(term));
 }
 
 /**


### PR DESCRIPTION
Three study-side changes, in the order they were made.

## Cram — a round of four cards through four stages

A new mode at `/collections/[id]/cram`, drawn from the same queue as blitz (due first, then longest unseen) and open to signed-in learners only.

Four cards, four exercises of rising difficulty, one stage at a time across the whole round:

| # | Stage | Prompt | Input |
|---|-------|--------|-------|
| 1 | Recognise | definition | choose the term, 4 options |
| 2 | Explain | term | choose the definition, 4 options |
| 3 | Spell | definition | assemble the term from its own letters |
| 4 | Write | definition | type the term, nothing offered |

- **A slip drops the card one stage** rather than repeating the question just answered for the learner, and the card waits for the next pass — that is the retry phase.
- **Two failures and the card leaves the round**, answer shown. A clean round is 16 steps, the worst 24.
- **One progress write per card**, when it leaves the round: clean → an ordinary correct answer (due-date gate still applies), missed the easiest stage → the failure blitz would report, faltered only at spelling/writing → nothing. No `retry` bypass, deliberately.
- **The round ends on its own cards** — every word with its definition and ✅ / 🌻 / ❌ — and "Go next" deals the next four without leaving the page.
- **The written stage is new UI**: a ruled line, graded on recall. Case, accents, punctuation and hyphen-vs-space normalised; `/` alternatives and parentheticals accepted either way; one typo (two in a long word) passes with the spelling shown.

Cards join a round only with a non-empty term and definition of 1–24 letters — a letterless term would deal an empty letter bank the spelling stage cannot end.

Also in this commit: the hint bulb becomes `components/HintButton.tsx` instead of a third copy, and the **Exercises** button that makes the existing worksheet session reachable from a collection at all.

## Connect

Links now start from **either column** — a definition can be picked first, not only used to break a link. The two verbs at the foot of the board ("Restart", "Try again") are replaced by a single **Go next**, which deals the next board; leaving sits beside it, pinned left with the verb centred.

## Typing

The letter bank spells the term **exactly as the card writes it**. `canonicalTerm` cut a slashed term down to its first alternative, which spells a phrase like "be/get bogged down" wrong; the slash is scaffolding like a space. Cards that meant "either of these" now ask for both halves.

## Testing

- `vitest` 100/100 — `lib/cram.test.ts` (34: round order, fall-back, the failure cap, emissions, option building, grading) and a new `lib/progress.test.ts` (11) covering the client mirror of the server's level arithmetic, which had no tests.
- `playwright` 23/23 against a seeded stack, including four cram cases: stage-major order, a wrong answer returning later, a clean round raising a level, and the button being inactive under five cards.
- `tsc` and `eslint` clean; `next build` passes.

Backend untouched — nothing about the mode is stored server-side.

## Not verified

Dark theme and mobile layout of the new screens were not looked at by eye, and the `h` hint shortcut has no test after the bulb moved into its own component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)